### PR TITLE
Update data and metadata structure and functionality

### DIFF
--- a/api/server.go
+++ b/api/server.go
@@ -3,6 +3,7 @@ package api
 import (
 	"context"
 	"errors"
+	"fmt"
 	"math/rand"
 	"net/http"
 	"os"
@@ -10,6 +11,7 @@ import (
 
 	"github.com/YaleSpinup/ds-api/common"
 	"github.com/YaleSpinup/ds-api/dataset"
+	"github.com/YaleSpinup/ds-api/s3datarepository"
 	"github.com/YaleSpinup/ds-api/s3metadatarepository"
 	"github.com/gorilla/handlers"
 	"github.com/gorilla/mux"
@@ -48,28 +50,58 @@ func NewServer(config common.Config) error {
 		return errors.New("'org' cannot be empty in the configuration")
 	}
 	Org = config.Org
-	repo := config.Repository
+	metadata := config.MetadataRepository
 
-	// Create metadata repository session
-	log.Debugf("Creating new MetadataRepository of type %s with configuration %+v (org: %s)", repo.Type, repo.Config, Org)
+	// Initialize metadata repository session
+	log.Debugf("Creating new session for MetadataRepository of type %s with configuration %+v (org: %s)", metadata.Type, metadata.Config, Org)
 
 	var metadataRepo dataset.MetadataRepository
 	var err error
-	switch repo.Type {
+	switch metadata.Type {
 	case "s3":
-		metadataRepo, err = s3metadatarepository.NewDefaultRepository(repo.Config)
+		if metadata.Config["prefix"] == nil {
+			metadata.Config["prefix"] = Org
+		} else {
+			metadata.Config["prefix"] = metadata.Config["prefix"].(string) + "/" + Org
+		}
+		metadataRepo, err = s3metadatarepository.NewDefaultRepository(metadata.Config)
 		if err != nil {
 			return err
 		}
 	default:
-		return errors.New("failed to determine metadata repository type, or type not supported: " + repo.Type)
+		return errors.New("failed to determine metadata repository type, or type not supported: " + metadata.Type)
 	}
 
-	// Create a shared session
-	for name, c := range config.Accounts {
-		log.Debugf("Creating new service for account '%s' with key '%s' in region '%s' (org: %s)", name, c.Akid, c.Region, Org)
+	// Create dataset service sessions
+	for name, a := range config.Accounts {
+		creds := map[string]interface{}{
+			"region":   a.Config.Region,
+			"akid":     a.Config.Akid,
+			"secret":   a.Config.Secret,
+			"endpoint": a.Config.Endpoint,
+		}
+		log.Debugf("Creating new service for account '%s' with key '%s' in region '%s' (org: %s, providers: %s)", name, creds["akid"], creds["region"], Org, a.StorageProviders)
+
+		dataRepos := make(map[string]dataset.DataRepository)
+
+		// initialize all supported data storage providers for each account
+		for _, p := range a.StorageProviders {
+			switch p {
+			case "s3":
+				dataRepo, err := s3datarepository.NewDefaultRepository(creds)
+				if err != nil {
+					return err
+				}
+				dataRepos["s3"] = dataRepo
+			default:
+				msg := fmt.Sprintf("failed to determine data repository provider for account %s, or storage provider not supported: %s", name, p)
+				return errors.New(msg)
+			}
+		}
+
 		s.datasetServices[name] = dataset.NewService(
 			dataset.WithMetadataRepository(metadataRepo),
+			dataset.WithDataRepository(dataRepos),
 		)
 	}
 

--- a/common/config.go
+++ b/common/config.go
@@ -22,15 +22,7 @@ type Config struct {
 // Account is the configuration for an individual account
 type Account struct {
 	StorageProviders []string
-	Config           AccountCredentials
-}
-
-// AccountCredentials is the auth credentials for an individual account
-type AccountCredentials struct {
-	Endpoint string
-	Region   string
-	Akid     string
-	Secret   string
+	Config           map[string]interface{}
 }
 
 // MetadataRepository is the configuration for the metadata respository

--- a/common/config.go
+++ b/common/config.go
@@ -10,25 +10,31 @@ import (
 
 // Config is representation of the configuration data
 type Config struct {
-	ListenAddress string
-	Accounts      map[string]Account
-	Repository    Repository
-	Token         string
-	LogLevel      string
-	Version       Version
-	Org           string
+	ListenAddress      string
+	Accounts           map[string]Account
+	MetadataRepository MetadataRepository
+	Token              string
+	LogLevel           string
+	Version            Version
+	Org                string
 }
 
 // Account is the configuration for an individual account
 type Account struct {
+	StorageProviders []string
+	Config           AccountCredentials
+}
+
+// AccountCredentials is the auth credentials for an individual account
+type AccountCredentials struct {
 	Endpoint string
 	Region   string
 	Akid     string
 	Secret   string
 }
 
-// Repository is the configuration for the metadata respository
-type Repository struct {
+// MetadataRepository is the configuration for the metadata respository
+type MetadataRepository struct {
 	Type   string
 	Config map[string]interface{}
 }

--- a/common/config_test.go
+++ b/common/config_test.go
@@ -51,18 +51,18 @@ func TestReadConfig(t *testing.T) {
 		Accounts: map[string]Account{
 			"provider1": Account{
 				StorageProviders: []string{"s3"},
-				Config: AccountCredentials{
-					Region: "us-east-1",
-					Akid:   "key1",
-					Secret: "secret1",
+				Config: map[string]interface{}{
+					"region": "us-east-1",
+					"akid":   "key1",
+					"secret": "secret1",
 				},
 			},
 			"provider2": Account{
 				StorageProviders: []string{"s3"},
-				Config: AccountCredentials{
-					Region: "us-west-1",
-					Akid:   "key2",
-					Secret: "secret2",
+				Config: map[string]interface{}{
+					"region": "us-west-1",
+					"akid":   "key2",
+					"secret": "secret2",
 				},
 			},
 		},

--- a/common/config_test.go
+++ b/common/config_test.go
@@ -9,29 +9,35 @@ import (
 var testConfig = []byte(
 	`{
 		"listenAddress": ":8000",
-		"accounts": {
-		  "provider1": {
-			"region": "us-east-1",
-			"akid": "key1",
-			"secret": "secret1"
-		  },
-		  "provider2": {
-			"region": "us-west-1",
-			"akid": "key2",
-			"secret": "secret2"
-		  }
-		},
-		"repository": {
+		"metadataRepository": {
 			"type": "s3",
 			"config": {
 			  "bucket": "some-metadata-repository",
 			  "region": "us-east-1",
-			  "akid": "key3",
-			  "secret": "secret3",
+			  "akid": "keymeta",
+			  "secret": "secretmeta",
 			  "endpoint": "https://s3.horseradishsys.com",
 			  "awesome": true
 			}
+		},
+		"accounts": {
+		  "provider1": {
+				"storageProviders": ["s3"],
+				"config": {
+					"region": "us-east-1",
+					"akid": "key1",
+					"secret": "secret1"
+				}
 		  },
+		  "provider2": {
+				"storageProviders": ["s3"],
+				"config": {
+					"region": "us-west-1",
+					"akid": "key2",
+					"secret": "secret2"
+				}
+		  }
+		},
 		"token": "SEKRET",
 		"logLevel": "info",
 		"org": "test"
@@ -44,23 +50,29 @@ func TestReadConfig(t *testing.T) {
 		ListenAddress: ":8000",
 		Accounts: map[string]Account{
 			"provider1": Account{
-				Region: "us-east-1",
-				Akid:   "key1",
-				Secret: "secret1",
+				StorageProviders: []string{"s3"},
+				Config: AccountCredentials{
+					Region: "us-east-1",
+					Akid:   "key1",
+					Secret: "secret1",
+				},
 			},
 			"provider2": Account{
-				Region: "us-west-1",
-				Akid:   "key2",
-				Secret: "secret2",
+				StorageProviders: []string{"s3"},
+				Config: AccountCredentials{
+					Region: "us-west-1",
+					Akid:   "key2",
+					Secret: "secret2",
+				},
 			},
 		},
-		Repository: Repository{
+		MetadataRepository: MetadataRepository{
 			Type: "s3",
 			Config: map[string]interface{}{
 				"bucket":   "some-metadata-repository",
 				"region":   "us-east-1",
-				"akid":     "key3",
-				"secret":   "secret3",
+				"akid":     "keymeta",
+				"secret":   "secretmeta",
 				"endpoint": "https://s3.horseradishsys.com",
 				"awesome":  true,
 			},

--- a/config/config.example.json
+++ b/config/config.example.json
@@ -1,10 +1,23 @@
 { 
   "listenAddress": ":8080",
-  "accounts": {
-    "someaccount": {
+  "metadataRepository": {
+    "type": "s3",
+    "config": {
+      "bucket": "dsapi-example-metadata-repository",
+      "prefix": "datasets",
       "region": "us-east-1",
       "akid": "xxxxxxxxxxxxxxxxxxxxxxxx",
       "secret": "yyyyyyyyyyyyyyyyyyyyyyyyyyyyyy"
+    }
+  },
+  "accounts": {
+    "someaccount": {
+      "storageProviders": ["s3"],
+      "config": {
+        "region": "us-east-1",
+        "akid": "xxxxxxxxxxxxxxxxxxxxxxxx",
+        "secret": "yyyyyyyyyyyyyyyyyyyyyyyyyyyyyy"
+      }
     }
   },
   "token": "xxxxxx",

--- a/dataset/dataset.go
+++ b/dataset/dataset.go
@@ -1,22 +1,33 @@
 package dataset
 
-import "github.com/google/uuid"
+import (
+	"github.com/google/uuid"
+)
 
-type ServiceOption func(*Service)
+// Service is a collection of one or more Data Repositories and a Matadata Repository for storing datasets
 type Service struct {
 	MetadataRepository MetadataRepository
-	DataRepository     DataRepository
+	DataRepository     map[string]DataRepository
 }
+
+// MetadataRepository is an interface for metadata repository
 type MetadataRepository interface {
-	Read(id string) ([]byte, error)
-	Save(id string, data []byte) error
+	Create(id string, data []byte) error
+	Get(id string) ([]byte, error)
+	Update(id string, data []byte) error
 	Delete(id string) error
 }
 
+// DataRepository is an interface for data repository
 type DataRepository interface {
 	Provision(id string) error
+	Deprovision(id string) error
 }
 
+// ServiceOption is a function to set service options
+type ServiceOption func(*Service)
+
+// NewService creates a new dataset service with the provided ServiceOption functions
 func NewService(opts ...ServiceOption) *Service {
 	s := Service{}
 
@@ -24,21 +35,24 @@ func NewService(opts ...ServiceOption) *Service {
 		opt(&s)
 	}
 
-	return &Service{}
+	return &s
 }
 
+// WithMetadataRepository sets the MetadataRepository for the service
 func WithMetadataRepository(repo MetadataRepository) ServiceOption {
 	return func(s *Service) {
 		s.MetadataRepository = repo
 	}
 }
 
-func WithDataRepository(repo DataRepository) ServiceOption {
+// WithDataRepository sets the DataRepository list for the service
+func WithDataRepository(repos map[string]DataRepository) ServiceOption {
 	return func(s *Service) {
-		s.DataRepository = repo
+		s.DataRepository = repos
 	}
 }
 
+// NewID generates a new dataset id
 func (s *Service) NewID() string {
 	return uuid.New().String()
 }

--- a/dataset/metadata.go
+++ b/dataset/metadata.go
@@ -19,6 +19,7 @@ type Metadata struct {
 	CreatedBy           string     `json:"created_by"`
 	DataClassifications []string   `json:"data_classifications"`
 	DataFormat          string     `json:"data_format"`
+	DataStorage         string     `json:"data_storage"`
 	Derivative          bool       `json:"derivative"`
 	DuaURL              *url.URL   `json:"dua_url"`
 	ModifiedAt          *time.Time `json:"modified_at"`
@@ -115,6 +116,15 @@ func (m *Metadata) UnmarshalJSON(j []byte) error {
 			return errors.New(msg)
 		} else {
 			m.DataFormat = s
+		}
+	}
+
+	if dataStorage, ok := rawStrings["data_storage"]; ok {
+		if s, ok := dataStorage.(string); !ok {
+			msg := fmt.Sprintf("data_storage is not a string: %+v", rawStrings["data_storage"])
+			return errors.New(msg)
+		} else {
+			m.DataStorage = s
 		}
 	}
 
@@ -232,6 +242,7 @@ func (m Metadata) MarshalJSON() ([]byte, error) {
 		CreatedBy           string   `json:"created_by"`
 		DataClassifications []string `json:"data_classifications"`
 		DataFormat          string   `json:"data_format"`
+		DataStorage         string   `json:"data_storage"`
 		Derivative          bool     `json:"derivative"`
 		DuaURL              string   `json:"dua_url"`
 		ModifiedAt          string   `json:"modified_at"`
@@ -246,6 +257,7 @@ func (m Metadata) MarshalJSON() ([]byte, error) {
 		CreatedBy:           m.CreatedBy,
 		DataClassifications: m.DataClassifications,
 		DataFormat:          m.DataFormat,
+		DataStorage:         m.DataStorage,
 		DuaURL:              duaURL,
 		ModifiedAt:          modifiedAt,
 		ModifiedBy:          m.ModifiedBy,

--- a/dataset/metadata_test.go
+++ b/dataset/metadata_test.go
@@ -18,6 +18,7 @@ func TestMetadataUnmarshalJSON(t *testing.T) {
 		"created_by": "zbrannigan",
 		"data_classifications": ["extremelyclassified"],
 		"data_format": "file",
+		"data_storage": "s3",
 		"derivative": false,
 		"dua_url": "https://allmydata.s3.amazonaws.com/duas/alien_dua.pdf",
 		"modified_at": "2015-11-21T04:19:01.123Z",
@@ -42,6 +43,7 @@ func TestMetadataUnmarshalJSON(t *testing.T) {
 		CreatedBy:           "zbrannigan",
 		DataClassifications: []string{"extremelyclassified"},
 		DataFormat:          "file",
+		DataStorage:         "s3",
 		Derivative:          false,
 		DuaURL:              duaURL,
 		ModifiedAt:          &modifiedAt,
@@ -171,7 +173,7 @@ func TestMetadataMarshalJSON(t *testing.T) {
 	tests := []test{
 		test{
 			Metadata{},
-			[]byte(`{"id":"","name":"","description":"","created_at":"","created_by":"","data_classifications":null,"data_format":"","derivative":false,"dua_url":"","modified_at":"","modified_by":"","proctor_response_url":"","source_id":null}`),
+			[]byte(`{"id":"","name":"","description":"","created_at":"","created_by":"","data_classifications":null,"data_format":"","data_storage":"","derivative":false,"dua_url":"","modified_at":"","modified_by":"","proctor_response_url":"","source_id":null}`),
 			nil,
 		},
 		test{
@@ -183,6 +185,7 @@ func TestMetadataMarshalJSON(t *testing.T) {
 				CreatedBy:           "zbrannigan",
 				DataClassifications: []string{"extremelyclassified"},
 				DataFormat:          "file",
+				DataStorage:         "s3",
 				Derivative:          false,
 				DuaURL:              duaURL,
 				ModifiedAt:          &modifiedAt,
@@ -194,7 +197,7 @@ func TestMetadataMarshalJSON(t *testing.T) {
 					"c00925d6-2eef-4fb6-aef1-87152613222c",
 				},
 			},
-			[]byte(`{"id":"08d754ba-8540-4fdc-92f3-47950c1cdb1c","name":"alien-sightings-dataset","description":"Alien sightings","created_at":"2013-06-19T19:14:01Z","created_by":"zbrannigan","data_classifications":["extremelyclassified"],"data_format":"file","derivative":false,"dua_url":"https://allmydata.s3.amazonaws.com/duas/alien_dua.pdf","modified_at":"2015-11-21T04:19:01Z","modified_by":"kkroker","proctor_response_url":"https://allmydata.s3.amazonaws.com/proctor/alien_study.json","source_id":["ea19d935-6ca3-4711-8e3e-24713cc3ac00","801e1c4f-58ff-4f14-af1f-0fd6a09cdaef","c00925d6-2eef-4fb6-aef1-87152613222c"]}`),
+			[]byte(`{"id":"08d754ba-8540-4fdc-92f3-47950c1cdb1c","name":"alien-sightings-dataset","description":"Alien sightings","created_at":"2013-06-19T19:14:01Z","created_by":"zbrannigan","data_classifications":["extremelyclassified"],"data_format":"file","data_storage":"s3","derivative":false,"dua_url":"https://allmydata.s3.amazonaws.com/duas/alien_dua.pdf","modified_at":"2015-11-21T04:19:01Z","modified_by":"kkroker","proctor_response_url":"https://allmydata.s3.amazonaws.com/proctor/alien_study.json","source_id":["ea19d935-6ca3-4711-8e3e-24713cc3ac00","801e1c4f-58ff-4f14-af1f-0fd6a09cdaef","c00925d6-2eef-4fb6-aef1-87152613222c"]}`),
 			nil,
 		},
 	}

--- a/go.sum
+++ b/go.sum
@@ -11,6 +11,7 @@ github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6r
 github.com/cespare/xxhash/v2 v2.1.1 h1:6MnRN8NT7+YBpUIWxHtefFZOKTAPgGjpQSxqLNn0+qY=
 github.com/cespare/xxhash/v2 v2.1.1/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/go-kit/kit v0.8.0/go.mod h1:xBxKIO96dXMWWy0MnWVtmwkA9/13aqxPnvrjFYMA2as=
 github.com/go-kit/kit v0.9.0/go.mod h1:xBxKIO96dXMWWy0MnWVtmwkA9/13aqxPnvrjFYMA2as=
@@ -24,6 +25,7 @@ github.com/golang/protobuf v1.3.1/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5y
 github.com/golang/protobuf v1.3.2 h1:6nsPYzhq5kReh6QImI3k5qWzO4PEbvbIW2cwSfR/6xs=
 github.com/golang/protobuf v1.3.2/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/google/go-cmp v0.3.1/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
+github.com/google/go-cmp v0.4.0 h1:xsAVV57WRhGj6kEIi8ReJzQlHHqcBYCElAvkovg3B/4=
 github.com/google/go-cmp v0.4.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/google/uuid v1.1.1 h1:Gkbcsh/GbpXz7lPftLA3P6TYMwjCLYm83jiFQZF/3gY=
@@ -40,8 +42,10 @@ github.com/julienschmidt/httprouter v1.2.0/go.mod h1:SYymIcj16QtmaHHD7aYtjjsJG7V
 github.com/konsorten/go-windows-terminal-sequences v1.0.1 h1:mweAR1A6xJ3oS2pRaGiHgQ4OO8tzTaLawm8vnODuwDk=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515/go.mod h1:+0opPa2QZZtGFBFZlji/RkVcI2GknAs/DXo4wKdlNEc=
+github.com/kr/pretty v0.1.0 h1:L/CwN0zerZDmRFUapSPitk6f+Q3+0za1rQkzVuMiMFI=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
+github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
 github.com/matttproud/golang_protobuf_extensions v1.0.1 h1:4hp9jkHxhMHkqkrB3Ix0jegS5sx/RkqARlsWZ6pIwiU=
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
@@ -54,6 +58,7 @@ github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINE
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/prometheus/client_golang v0.9.1/go.mod h1:7SWBe2y4D6OKWSNQJUaRYU/AaXPKyh/dDVn+NZz0KFw=
 github.com/prometheus/client_golang v1.0.0/go.mod h1:db9x61etRT2tGnBNRi70OPL5FsnadC4Ky3P0J6CfImo=
@@ -77,11 +82,13 @@ github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
+github.com/stretchr/testify v1.4.0 h1:2E4SXV/wtOkTonXsotYi4li6zVWxYlZuYNCXe9XRJyk=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 golang.org/x/crypto v0.0.0-20180904163835-0709b304e793/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/net v0.0.0-20181114220301-adae6a3d119a/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20190613194153-d28f0bde5980/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
+golang.org/x/net v0.0.0-20200202094626-16171245cfb2 h1:CCH4IOTTfewWjGOlSp+zGcjutRKlBEZQ6wTn8ozI/nI=
 golang.org/x/net v0.0.0-20200202094626-16171245cfb2/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/sync v0.0.0-20181108010431-42b317875d0f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20181221193216-37e7f081c4d4/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
@@ -92,12 +99,16 @@ golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5h
 golang.org/x/sys v0.0.0-20190422165155-953cdadca894/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200122134326-e047566fdf82 h1:ywK/j/KkyTHcdyYSZNXGjMwgmDSfjglYZ3vStQ/gSCU=
 golang.org/x/sys v0.0.0-20200122134326-e047566fdf82/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/text v0.3.0 h1:g61tztE5qeGQ89tm6NTjjM9VPIm088od1l6aSorWRWg=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
+golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 h1:E7g+9GITq07hpfrRu66IVDexMakfv52eLZ2CXBWiKr4=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 gopkg.in/alecthomas/kingpin.v2 v2.2.6/go.mod h1:FMv+mEhP44yOT+4EoQTLFTRgOQ1FBLkstjWtayDeSgw=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 h1:YR8cESwS4TdDjEe65xsg0ogRM/Nc3DYOhEAlW+xobZo=
 gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v2 v2.2.1/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.4/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
+gopkg.in/yaml.v2 v2.2.5 h1:ymVxjfMaHvXD8RqPRmzHHsB3VvucivSkIAvJFDI5O3c=
 gopkg.in/yaml.v2 v2.2.5/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=

--- a/s3datarepository/s3datarepository.go
+++ b/s3datarepository/s3datarepository.go
@@ -1,4 +1,4 @@
-package s3metadatarepository
+package s3datarepository
 
 import (
 	"github.com/aws/aws-sdk-go/aws"
@@ -12,7 +12,7 @@ import (
 // S3RepositoryOption is a function to set repository options
 type S3RepositoryOption func(*S3Repository)
 
-// S3Repository is an implementation of a metadata respository in S3
+// S3Repository is an implementation of a data respository in S3
 type S3Repository struct {
 	S3     s3iface.S3API
 	Bucket string
@@ -76,7 +76,7 @@ func NewDefaultRepository(config map[string]interface{}) (*S3Repository, error) 
 
 // New creates an S3Repository from a list of S3RepositoryOption functions
 func New(opts ...S3RepositoryOption) (*S3Repository, error) {
-	log.Info("creating new s3 metadata repository provider")
+	log.Info("creating new s3 repository provider")
 
 	s := S3Repository{}
 	s.config = aws.NewConfig()
@@ -143,26 +143,14 @@ func WithPrefix(prefix string) S3RepositoryOption {
 // 	}
 // }
 
-// Create creates a new metadata object in the repository
-func (s *S3Repository) Create(id string, data []byte) error {
-	log.Debugf("creating s3metadatarepository object with id: %s\n%+v", id, string(data))
+// Provision satisfies the ability to provision a data repository
+func (s *S3Repository) Provision(id string) error {
+	log.Debugf("provisioning s3datarepository with id: %s", id)
 	return nil
 }
 
-// Get gets a metadata object from the repository by id
-func (s *S3Repository) Get(id string) ([]byte, error) {
-	log.Debugf("getting s3metadatarepository object with id: %s", id)
-	return []byte{}, nil
-}
-
-// Update updates a metadata object in the repository
-func (s *S3Repository) Update(id string, data []byte) error {
-	log.Debugf("updating s3metadatarepository object with id: %s\n%+v", id, string(data))
-	return nil
-}
-
-// Delete deletes a metadata object from the repository by id
-func (s *S3Repository) Delete(id string) error {
-	log.Debugf("deleting s3metadatarepository object with id: %s", id)
+// Deprovision satisfies the ability to deprovision a data repository
+func (s *S3Repository) Deprovision(id string) error {
+	log.Debugf("deprovisioning s3datarepository with id: %s", id)
 	return nil
 }


### PR DESCRIPTION
This PR adds support for an S3 data repository and updates some of the core functionality for the dataset Service and Metadata.
Each `dataset.Service` now contains a `MetadataRepository` (defined in the config) and a list of `DataRepository` storage providers (defined in the config for each account).