### PR TITLE
Add role access provisioning for datasets

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ GET /v1/ds/version
 GET /v1/ds/metrics
 
 POST /v1/ds/{account}/datasets
+GET /v1/ds/{account}/datasets/{id}
 ```
 
 ## Usage
@@ -94,6 +95,74 @@ POST /v1/ds/{account}/datasets
 | **429 Too Many Requests**     | service or rate limit exceeded       |
 | **500 Internal Server Error** | a server error occurred              |
 | **503 Service Unavailable**   | an AWS service is unavailable        |
+
+### Get information about a dataset
+
+GET /v1/ds/{account}/datasets/{id}
+
+```json
+{
+    "id": "bb4f6316-53e2-45ae-97c7-fa7fd17f78a8",
+    "metadata": {
+        "id": "bb4f6316-53e2-45ae-97c7-fa7fd17f78a8",
+        "name": "awesome-dataset-of-stuff",
+        "description": "The hugest dataset of awesome stuff",
+        "created_at": "2020-03-16T15:38:14Z",
+        "created_by": "drzoidberg",
+        "data_classifications": [
+            "hipaa",
+            "pii"
+        ],
+        "data_format": "file",
+        "data_storage": "s3",
+        "derivative": true,
+        "dua_url": "https://allmydata.s3.amazonaws.com/duas/huge_awesome_dua.pdf",
+        "modified_at": "2020-03-16T15:38:14Z",
+        "modified_by": "pfry",
+        "proctor_response_url": "https://allmydata.s3.amazonaws.com/proctor/huge_awesome_study.json",
+        "source_ids": [
+            "d37b375b-d136-4b17-8666-5036dc554a66",
+        ]
+    },
+    "repository": {
+        "name": "dataset-localdev-bb4f6316-53e2-45ae-97c7-fa7fd17f78a8",
+        "tags": [
+            {
+                "key": "CreatedBy",
+                "value": "SomeGuy"
+            },
+            {
+                "key": "spinup:org",
+                "value": "localdev"
+            },
+            {
+                "key": "ID",
+                "value": "bb4f6316-53e2-45ae-97c7-fa7fd17f78a8"
+            },
+            {
+                "key": "COA",
+                "value": "Take.My.Money"
+            },
+            {
+                "key": "Application",
+                "value": "ButWhyyyyy"
+            },
+            {
+                "key": "Name",
+                "value": "awesome-dataset-of-stuff"
+            }
+        ]
+    }
+}
+```
+
+| Response Code                 | Definition                           |
+| ----------------------------- | -------------------------------------|
+| **200 OK**                    | okay                                 |
+| **400 Bad Request**           | badly formed request                 |
+| **404 Not Found**             | dataset not found                    |
+| **500 Internal Server Error** | a server error occurred              |
+
 
 ## Authentication
 

--- a/README.md
+++ b/README.md
@@ -168,6 +168,51 @@ GET /v1/ds/{account}/datasets/{id}
 
 Authentication is accomplished using a pre-shared key via the `X-Auth-Token` header.
 
+## API Configuration
+
+API configuration is via `config/config.json`, an example config file is provided.
+
+You can specify a single `metadataRepository` where metadata about all the different data sets will be stored. Currently, the only supported type is `s3`, so you need to provide an S3 bucket and credentials with full access to that bucket. For example, if you created a bucket called `spinup-example-metadata-repository`, then the IAM policy would be:
+```
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Effect": "Allow",
+            "Action": "s3:*",
+            "Resource": "arn:aws:s3:::spinup-example-metadata-repository/*"
+        }
+    ]
+}
+```
+
+You can then define a list of `accounts` for the actual dataset repositories - that's where the data sets will be stored. Currently, the only supported type is `s3`, so you need to provide credentials in each account with the appropriate S3 and IAM access. This is a good starting IAM policy if you don't modify the default name and path prefixes:
+```
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Effect": "Allow",
+            "Action": "iam:*",
+            "Resource": [
+                "arn:aws:iam::*:role/spinup/dataset/*",
+                "arn:aws:iam::*:instance-profile/spinup/dataset/*",
+                "arn:aws:iam::*:group/spinup/dataset/*",
+                "arn:aws:iam::*:user/spinup/dataset/*",
+                "arn:aws:iam::*:policy/spinup/dataset/*"
+            ]
+        },
+        {
+            "Effect": "Allow",
+            "Action": "s3:*",
+            "Resource": [
+                "arn:aws:s3::*:dataset-*"
+            ]
+        }
+    ]
+}
+```
+
 ## Authors
 
 E Camden Fisher <camden.fisher@yale.edu>

--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@ POST /v1/ds/{account}/datasets
 ```json
 {
     "name": "awesome-dataset-of-stuff",
+    "type": "s3",
+    "derivative": true,
     "tags": [
         { "key": "Application", "value": "ButWhyyyyy" },
         { "key": "COA", "value": "Take.My.Money" },
@@ -34,7 +36,6 @@ POST /v1/ds/{account}/datasets
         "created_by": "drzoidberg",
         "data_classifications": ["hipaa","pii"],
         "data_format": "file",
-        "derivative": true,
         "dua_url": "https://allmydata.s3.amazonaws.com/duas/huge_awesome_dua.pdf",
         "modified_at": "2019-03-28T07:36:01.123Z",
         "modified_by": "pfry",
@@ -48,9 +49,38 @@ POST /v1/ds/{account}/datasets
 
 ```json
 {
-    "ID": "c380ba10-1dbe-4377-a9eb-5e14d8212962",
-    "Bucket": "/awesome-dataset-bucketname",
-    "Resources": [],
+    "id": "d37b375b-d136-4b17-8666-5036dc554a66",
+    "repository": "dataset-localdev-d37b375b-d136-4b17-8666-5036dc554a66",
+    "metadata": {
+        "id": "d37b375b-d136-4b17-8666-5036dc554a66",
+        "name": "awesome-dataset-of-stuff",
+        "description": "The hugest dataset of awesome stuff",
+        "created_at": "2020-03-11T18:41:32Z",
+        "created_by": "drzoidberg",
+        "data_classifications": [
+            "hipaa",
+            "pii"
+        ],
+        "data_format": "file",
+        "data_storage": "s3",
+        "derivative": true,
+        "dua_url": "https://allmydata.s3.amazonaws.com/duas/huge_awesome_dua.pdf",
+        "modified_at": "2020-03-11T18:41:32Z",
+        "modified_by": "pfry",
+        "proctor_response_url": "https://allmydata.s3.amazonaws.com/proctor/huge_awesome_study.json",
+        "source_ids": [
+            "e15d2282-9c68-46b5-801c-2b5a62484624",
+            "a7c082ee-f711-48fa-8a57-25c95b3a6ddd"
+        ]
+    },
+    "access": {
+        "instance_profile_arn": "arn:aws:iam::516855177326:instance-profile/roleDataset_d37b375b-d136-4b17-8666-5036dc554a66",
+        "instance_profile_name": "roleDataset_d37b375b-d136-4b17-8666-5036dc554a66",
+        "policy_arn": "arn:aws:iam::516855177326:policy/dataset-localdev-d37b375b-d136-4b17-8666-5036dc554a66-DerivativePlc",
+        "policy_name": "dataset-localdev-d37b375b-d136-4b17-8666-5036dc554a66-DerivativePlc",
+        "role_arn": "arn:aws:iam::516855177326:role/roleDataset_d37b375b-d136-4b17-8666-5036dc554a66",
+        "role_name": "roleDataset_d37b375b-d136-4b17-8666-5036dc554a66"
+    }
 }
 ```
 
@@ -69,9 +99,10 @@ POST /v1/ds/{account}/datasets
 
 Authentication is accomplished using a pre-shared key via the `X-Auth-Token` header.
 
-## Author
+## Authors
 
 E Camden Fisher <camden.fisher@yale.edu>
+Tenyo Grozev <tenyo.grozev@yale.edu>
 
 ## License
 

--- a/api/handlers_datasets.go
+++ b/api/handlers_datasets.go
@@ -127,7 +127,7 @@ func (s *server) DatasetCreateHandler(w http.ResponseWriter, r *http.Request) {
 	})
 
 	// grant appropriate dataset access
-	var datasetAccess *dataset.Access
+	var datasetAccess dataset.Access
 	log.Infof("granting dataset access for %s (derivative: %t)", id, input.Derivative)
 	datasetAccess, err = dataRepo.GrantAccess(r.Context(), id, input.Derivative)
 	if err != nil {
@@ -157,7 +157,7 @@ func (s *server) DatasetCreateHandler(w http.ResponseWriter, r *http.Request) {
 		ID         string            `json:"id"`
 		Repository string            `json:"repository"`
 		Metadata   *dataset.Metadata `json:"metadata"`
-		Access     *dataset.Access   `json:"access"`
+		Access     dataset.Access    `json:"access"`
 	}{
 		id,
 		dataRepoName,

--- a/dataset/dataset.go
+++ b/dataset/dataset.go
@@ -22,10 +22,15 @@ type MetadataRepository interface {
 
 // DataRepository is an interface for data repository
 type DataRepository interface {
-	Provision(ctx context.Context, id string, tags []*Tag) error
+	Provision(ctx context.Context, id string, tags []*Tag) (string, error)
 	Deprovision(ctx context.Context, id string) error
 	Delete(ctx context.Context, id string) error
+	GrantAccess(ctx context.Context, id string, derivative bool) (*Access, error)
+	RevokeAccess(ctx context.Context, id string) error
 }
+
+// Access contains necessary information in order to access a dataset
+type Access map[string]string
 
 // ServiceOption is a function to set service options
 type ServiceOption func(*Service)

--- a/dataset/dataset.go
+++ b/dataset/dataset.go
@@ -25,6 +25,7 @@ type DataRepository interface {
 	Provision(ctx context.Context, id string, tags []*Tag) (string, error)
 	Deprovision(ctx context.Context, id string) error
 	Delete(ctx context.Context, id string) error
+	Describe(ctx context.Context, id string) (*Repository, error)
 	GrantAccess(ctx context.Context, id string, derivative bool) (*Access, error)
 	RevokeAccess(ctx context.Context, id string) error
 }

--- a/dataset/dataset.go
+++ b/dataset/dataset.go
@@ -26,7 +26,7 @@ type DataRepository interface {
 	Deprovision(ctx context.Context, id string) error
 	Delete(ctx context.Context, id string) error
 	Describe(ctx context.Context, id string) (*Repository, error)
-	GrantAccess(ctx context.Context, id string, derivative bool) (*Access, error)
+	GrantAccess(ctx context.Context, id string, derivative bool) (Access, error)
 	RevokeAccess(ctx context.Context, id string) error
 }
 

--- a/dataset/repository.go
+++ b/dataset/repository.go
@@ -1,0 +1,13 @@
+package dataset
+
+// Repository is information about a data repository
+type Repository struct {
+	Name string `json:"name"`
+	Tags []*Tag `json:"tags"`
+}
+
+// Tag is the structure of a data repository tag
+type Tag struct {
+	Key   *string `json:"key"`
+	Value *string `json:"value"`
+}

--- a/dataset/tag.go
+++ b/dataset/tag.go
@@ -1,6 +1,0 @@
-package dataset
-
-type Tag struct {
-	Key   *string `json:"key"`
-	Value *string `json:"value"`
-}

--- a/docker/config.deco.json
+++ b/docker/config.deco.json
@@ -1,10 +1,31 @@
 { 
   "listenAddress": ":8080",
+  "metadataRepository": {
+    "type": "s3",
+    "config": {
+      "bucket": "{{ .metadata_bucket }}",
+      "prefix": "datasets",
+      "region": "us-east-1",
+      "akid": "{{ .metadata_akid }}",
+      "secret": "{{ .metadata_secret }}"
+    }
+  },
   "accounts": {
     "spinup": {
-      "region": "us-east-1",
-      "akid": "{{ .spinup_akid }}",
-      "secret": "{{ .spinup_secret }}",
+      "storageProviders": ["s3"],
+      "config": {
+        "region": "us-east-1",
+        "akid": "{{ .spinup_akid }}",
+        "secret": "{{ .spinup_secret }}"
+      }
+    },
+    "spinupsec": {
+      "storageProviders": ["s3"],
+      "config": {
+        "region": "us-east-1",
+        "akid": "{{ .spinupsec_akid }}",
+        "secret": "{{ .spinupsec_secret }}"
+      }
     }
   },
   "token": "{{ .api_token }}",

--- a/go.sum
+++ b/go.sum
@@ -25,6 +25,7 @@ github.com/golang/protobuf v1.3.1/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5y
 github.com/golang/protobuf v1.3.2 h1:6nsPYzhq5kReh6QImI3k5qWzO4PEbvbIW2cwSfR/6xs=
 github.com/golang/protobuf v1.3.2/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/google/go-cmp v0.3.1/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
+github.com/google/go-cmp v0.4.0 h1:xsAVV57WRhGj6kEIi8ReJzQlHHqcBYCElAvkovg3B/4=
 github.com/google/go-cmp v0.4.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/google/uuid v1.1.1 h1:Gkbcsh/GbpXz7lPftLA3P6TYMwjCLYm83jiFQZF/3gY=
@@ -38,10 +39,13 @@ github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af/go.mod h1:Nht
 github.com/json-iterator/go v1.1.6/go.mod h1:+SdeFBvtyEkXs7REEP0seUULqWtbJapLOCVDaaPEHmU=
 github.com/json-iterator/go v1.1.9/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/uOdHXbAo4=
 github.com/julienschmidt/httprouter v1.2.0/go.mod h1:SYymIcj16QtmaHHD7aYtjjsJG7VTCxuUUipMqKk8s4w=
+github.com/konsorten/go-windows-terminal-sequences v1.0.1 h1:mweAR1A6xJ3oS2pRaGiHgQ4OO8tzTaLawm8vnODuwDk=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515/go.mod h1:+0opPa2QZZtGFBFZlji/RkVcI2GknAs/DXo4wKdlNEc=
+github.com/kr/pretty v0.1.0 h1:L/CwN0zerZDmRFUapSPitk6f+Q3+0za1rQkzVuMiMFI=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
+github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
 github.com/matttproud/golang_protobuf_extensions v1.0.1 h1:4hp9jkHxhMHkqkrB3Ix0jegS5sx/RkqARlsWZ6pIwiU=
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
@@ -97,9 +101,11 @@ golang.org/x/sys v0.0.0-20200122134326-e047566fdf82 h1:ywK/j/KkyTHcdyYSZNXGjMwgm
 golang.org/x/sys v0.0.0-20200122134326-e047566fdf82/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.3.0 h1:g61tztE5qeGQ89tm6NTjjM9VPIm088od1l6aSorWRWg=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
+golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 h1:E7g+9GITq07hpfrRu66IVDexMakfv52eLZ2CXBWiKr4=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 gopkg.in/alecthomas/kingpin.v2 v2.2.6/go.mod h1:FMv+mEhP44yOT+4EoQTLFTRgOQ1FBLkstjWtayDeSgw=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 h1:YR8cESwS4TdDjEe65xsg0ogRM/Nc3DYOhEAlW+xobZo=
 gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v2 v2.2.1/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=

--- a/s3datarepository/errors.go
+++ b/s3datarepository/errors.go
@@ -3,6 +3,7 @@ package s3datarepository
 import (
 	"github.com/YaleSpinup/ds-api/apierror"
 	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/aws/aws-sdk-go/service/iam"
 	"github.com/aws/aws-sdk-go/service/s3"
 	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
@@ -29,6 +30,42 @@ func ErrCode(msg string, err error) error {
 
 			return apierror.New(apierror.ErrForbidden, msg, aerr)
 		case
+			// ErrCodeConcurrentModificationException for service response error code
+			// "ConcurrentModification".
+			//
+			// The request was rejected because multiple requests to change this object
+			// were submitted simultaneously. Wait a few minutes and submit your request
+			// again.
+			iam.ErrCodeConcurrentModificationException,
+
+			// ErrCodeDeleteConflictException for service response error code
+			// "DeleteConflict".
+			//
+			// The request was rejected because it attempted to delete a resource that has
+			// attached subordinate entities. The error message describes these entities.
+			iam.ErrCodeDeleteConflictException,
+
+			// ErrCodeDuplicateCertificateException for service response error code
+			// "DuplicateCertificate".
+			//
+			// The request was rejected because the same certificate is associated with
+			// an IAM user in the account.
+			iam.ErrCodeDuplicateCertificateException,
+
+			// ErrCodeDuplicateSSHPublicKeyException for service response error code
+			// "DuplicateSSHPublicKey".
+			//
+			// The request was rejected because the SSH public key is already associated
+			// with the specified IAM user.
+			iam.ErrCodeDuplicateSSHPublicKeyException,
+
+			// ErrCodeEntityAlreadyExistsException for service response error code
+			// "EntityAlreadyExists".
+			//
+			// The request was rejected because it attempted to create a resource that already
+			// exists.
+			iam.ErrCodeEntityAlreadyExistsException,
+
 			// ErrCodeBucketAlreadyExists for service response error code
 			// "BucketAlreadyExists".
 			//
@@ -53,6 +90,13 @@ func ErrCode(msg string, err error) error {
 			"RestoreAlreadyInProgress":
 			return apierror.New(apierror.ErrConflict, msg, aerr)
 		case
+			// ErrCodeNoSuchEntityException for service response error code
+			// "NoSuchEntity".
+			//
+			// The request was rejected because it referenced a resource entity that does
+			// not exist. The error message describes the resource.
+			iam.ErrCodeNoSuchEntityException,
+
 			// ErrCodeNoSuchBucket for service response error code
 			// "NoSuchBucket".
 			//
@@ -85,6 +129,121 @@ func ErrCode(msg string, err error) error {
 			return apierror.New(apierror.ErrNotFound, msg, aerr)
 
 		case
+			// ErrCodeCredentialReportExpiredException for service response error code
+			// "ReportExpired".
+			//
+			// The request was rejected because the most recent credential report has expired.
+			// To generate a new credential report, use GenerateCredentialReport. For more
+			// information about credential report expiration, see Getting Credential Reports
+			// (https://docs.aws.amazon.com/IAM/latest/UserGuide/credential-reports.html)
+			// in the IAM User Guide.
+			iam.ErrCodeCredentialReportExpiredException,
+
+			// ErrCodeCredentialReportNotPresentException for service response error code
+			// "ReportNotPresent".
+			//
+			// The request was rejected because the credential report does not exist. To
+			// generate a credential report, use GenerateCredentialReport.
+			iam.ErrCodeCredentialReportNotPresentException,
+
+			// ErrCodeCredentialReportNotReadyException for service response error code
+			// "ReportInProgress".
+			//
+			// The request was rejected because the credential report is still being generated.
+			iam.ErrCodeCredentialReportNotReadyException,
+
+			// ErrCodeEntityTemporarilyUnmodifiableException for service response error code
+			// "EntityTemporarilyUnmodifiable".
+			//
+			// The request was rejected because it referenced an entity that is temporarily
+			// unmodifiable, such as a user name that was deleted and then recreated. The
+			// error indicates that the request is likely to succeed if you try again after
+			// waiting several minutes. The error message describes the entity.
+			iam.ErrCodeEntityTemporarilyUnmodifiableException,
+
+			// ErrCodeInvalidAuthenticationCodeException for service response error code
+			// "InvalidAuthenticationCode".
+			//
+			// The request was rejected because the authentication code was not recognized.
+			// The error message describes the specific error.
+			iam.ErrCodeInvalidAuthenticationCodeException,
+
+			// ErrCodeInvalidCertificateException for service response error code
+			// "InvalidCertificate".
+			//
+			// The request was rejected because the certificate is invalid.
+			iam.ErrCodeInvalidCertificateException,
+
+			// ErrCodeInvalidInputException for service response error code
+			// "InvalidInput".
+			//
+			// The request was rejected because an invalid or out-of-range value was supplied
+			// for an input parameter.
+			iam.ErrCodeInvalidInputException,
+
+			// ErrCodeInvalidPublicKeyException for service response error code
+			// "InvalidPublicKey".
+			//
+			// The request was rejected because the public key is malformed or otherwise
+			// invalid.
+			iam.ErrCodeInvalidPublicKeyException,
+
+			// ErrCodeInvalidUserTypeException for service response error code
+			// "InvalidUserType".
+			//
+			// The request was rejected because the type of user for the transaction was
+			// incorrect.
+			iam.ErrCodeInvalidUserTypeException,
+
+			// ErrCodeKeyPairMismatchException for service response error code
+			// "KeyPairMismatch".
+			//
+			// The request was rejected because the public key certificate and the private
+			// key do not match.
+			iam.ErrCodeKeyPairMismatchException,
+
+			// ErrCodeMalformedCertificateException for service response error code
+			// "MalformedCertificate".
+			//
+			// The request was rejected because the certificate was malformed or expired.
+			// The error message describes the specific error.
+			iam.ErrCodeMalformedCertificateException,
+
+			// ErrCodeMalformedPolicyDocumentException for service response error code
+			// "MalformedPolicyDocument".
+			//
+			// The request was rejected because the policy document was malformed. The error
+			// message describes the specific error.
+			iam.ErrCodeMalformedPolicyDocumentException,
+
+			// ErrCodePasswordPolicyViolationException for service response error code
+			// "PasswordPolicyViolation".
+			//
+			// The request was rejected because the provided password did not meet the requirements
+			// imposed by the account password policy.
+			iam.ErrCodePasswordPolicyViolationException,
+
+			// ErrCodePolicyEvaluationException for service response error code
+			// "PolicyEvaluation".
+			//
+			// The request failed because a provided policy could not be successfully evaluated.
+			// An additional detailed message indicates the source of the failure.
+			iam.ErrCodePolicyEvaluationException,
+
+			// ErrCodePolicyNotAttachableException for service response error code
+			// "PolicyNotAttachable".
+			//
+			// The request failed because AWS service role policies can only be attached
+			// to the service-linked role for that service.
+			iam.ErrCodePolicyNotAttachableException,
+
+			// ErrCodeUnrecognizedPublicKeyEncodingException for service response error code
+			// "UnrecognizedPublicKeyEncoding".
+			//
+			// The request was rejected because the public key encoding format is unsupported
+			// or unrecognized.
+			iam.ErrCodeUnrecognizedPublicKeyEncodingException,
+
 			// ErrCodeObjectAlreadyInActiveTierError for service response error code
 			// "ObjectAlreadyInActiveTierError".
 			//
@@ -255,6 +414,20 @@ func ErrCode(msg string, err error) error {
 
 			return apierror.New(apierror.ErrBadRequest, msg, aerr)
 		case
+			// ErrCodeLimitExceededException for service response error code
+			// "LimitExceeded".
+			//
+			// The request was rejected because it attempted to create resources beyond
+			// the current AWS account limits. The error message describes the limit exceeded.
+			iam.ErrCodeLimitExceededException,
+
+			// ErrCodeReportGenerationLimitExceededException for service response error code
+			// "ReportGenerationLimitExceeded".
+			//
+			// The request failed because the maximum number of concurrent requests for
+			// this account are already running.
+			iam.ErrCodeReportGenerationLimitExceededException,
+
 			// Your request was too big.
 			"MaxMessageLengthExceeded",
 
@@ -275,6 +448,19 @@ func ErrCode(msg string, err error) error {
 
 			return apierror.New(apierror.ErrLimitExceeded, msg, aerr)
 		case
+			// ErrCodeServiceFailureException for service response error code
+			// "ServiceFailure".
+			//
+			// The request processing has failed because of an unknown error, exception
+			// or failure.
+			iam.ErrCodeServiceFailureException,
+
+			// ErrCodeServiceNotSupportedException for service response error code
+			// "NotSupportedService".
+			//
+			// The specified service does not support service-specific credentials.
+			iam.ErrCodeServiceNotSupportedException,
+
 			// All access to this object has been disabled. Please contact AWS Support for further assistance.
 			"InvalidPayer",
 

--- a/s3datarepository/iam.go
+++ b/s3datarepository/iam.go
@@ -29,7 +29,7 @@ type PolicyDoc struct {
 
 // GrantAccess sets up the appropriate access to the data repository, depending if it's a derivative or not,
 // and returns a list of Policy/Role names
-func (s *S3Repository) GrantAccess(ctx context.Context, id string, derivative bool) (*dataset.Access, error) {
+func (s *S3Repository) GrantAccess(ctx context.Context, id string, derivative bool) (dataset.Access, error) {
 	if id == "" {
 		return nil, apierror.New(apierror.ErrBadRequest, "invalid input", errors.New("empty id"))
 	}
@@ -184,7 +184,7 @@ func (s *S3Repository) GrantAccess(ctx context.Context, id string, derivative bo
 
 	log.Debugf("created instance profile %s", roleName)
 
-	output := &dataset.Access{
+	output := dataset.Access{
 		"policy_arn":            aws.StringValue(policyOutput.Policy.Arn),
 		"policy_name":           aws.StringValue(policyOutput.Policy.PolicyName),
 		"role_arn":              aws.StringValue(roleOutput.Role.Arn),

--- a/s3datarepository/iam.go
+++ b/s3datarepository/iam.go
@@ -1,0 +1,427 @@
+package s3datarepository
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+
+	"github.com/YaleSpinup/ds-api/apierror"
+	"github.com/YaleSpinup/ds-api/dataset"
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/iam"
+	log "github.com/sirupsen/logrus"
+)
+
+// PolicyStatement is an individual IAM Policy statement
+type PolicyStatement struct {
+	Effect    string
+	Action    []string
+	Resource  []string            `json:",omitempty"`
+	Principal map[string][]string `json:",omitempty"`
+}
+
+// PolicyDoc collects the policy statements
+type PolicyDoc struct {
+	Version   string
+	Statement []PolicyStatement
+}
+
+// GrantAccess sets up the appropriate access to the data repository, depending if it's a derivative or not,
+// and returns a list of Policy/Role names
+func (s *S3Repository) GrantAccess(ctx context.Context, id string, derivative bool) (*dataset.Access, error) {
+	if id == "" {
+		return nil, apierror.New(apierror.ErrBadRequest, "invalid input", errors.New("empty id"))
+	}
+
+	name := id
+	if s.NamePrefix != "" {
+		name = s.NamePrefix + "-" + name
+	}
+
+	log.Debugf("granting access to s3datarepository: %s (derivative: %t)", name, derivative)
+
+	var policyDoc []byte
+	var policyName string
+	var err error
+
+	if derivative {
+		policyName = fmt.Sprintf("%s-DerivativePlc", name)
+		policyDoc, err = s.derivativeAccessPolicy(name)
+	} else {
+		policyName = fmt.Sprintf("%s-OriginalPlc", name)
+		policyDoc, err = s.originalAccessPolicy(name)
+	}
+	if err != nil {
+		return nil, ErrCode("failed to generate IAM policy for bucket "+name, err)
+	}
+
+	log.Debugf("creating access policy for bucket '%s'", name)
+
+	// setup rollback function list and defer execution
+	var rollBackTasks []func() error
+	defer func() {
+		if err != nil {
+			log.Errorf("recovering from error granting access to s3datarepository: %s, executing %d rollback tasks", err, len(rollBackTasks))
+			rollBack(&rollBackTasks)
+		}
+	}()
+
+	policyOutput, err := s.IAM.CreatePolicyWithContext(ctx, &iam.CreatePolicyInput{
+		Description:    aws.String(fmt.Sprintf("Access policy for bucket %s", name)),
+		PolicyDocument: aws.String(string(policyDoc)),
+		PolicyName:     aws.String(policyName),
+	})
+	if err != nil {
+		return nil, ErrCode("failed to create IAM policy", err)
+	}
+
+	// append policy delete to rollback tasks
+	rbfunc := func() error {
+		return func() error {
+			if _, err := s.IAM.DeletePolicyWithContext(ctx, &iam.DeletePolicyInput{PolicyArn: policyOutput.Policy.Arn}); err != nil {
+				return err
+			}
+			return nil
+		}()
+	}
+	rollBackTasks = append(rollBackTasks, rbfunc)
+
+	// create role
+	roleName := fmt.Sprintf("roleDataset_%s", id)
+	roleDoc, err := s.assumeRolePolicy(name)
+	if err != nil {
+		return nil, ErrCode("failed to generate IAM assume role policy for bucket "+name, err)
+	}
+
+	log.Debugf("creating role for accessing bucket '%s'", name)
+
+	roleOutput, err := s.IAM.CreateRoleWithContext(ctx, &iam.CreateRoleInput{
+		AssumeRolePolicyDocument: aws.String(string(roleDoc)),
+		Description:              aws.String(fmt.Sprintf("Role for accessing bucket %s", name)),
+		Path:                     aws.String("/"),
+		RoleName:                 aws.String(roleName),
+	})
+	if err != nil {
+		return nil, ErrCode("failed to create IAM role "+roleName, err)
+	}
+
+	// append role delete to rollback tasks
+	rbfunc = func() error {
+		return func() error {
+			if _, err := s.IAM.DeleteRoleWithContext(ctx, &iam.DeleteRoleInput{RoleName: roleOutput.Role.RoleName}); err != nil {
+				return err
+			}
+			return nil
+		}()
+	}
+	rollBackTasks = append(rollBackTasks, rbfunc)
+
+	// attach access policy to the role
+	_, err = s.IAM.AttachRolePolicyWithContext(ctx, &iam.AttachRolePolicyInput{
+		PolicyArn: policyOutput.Policy.Arn,
+		RoleName:  aws.String(roleName),
+	})
+	if err != nil {
+		return nil, ErrCode("failed to attach policy to role "+roleName, err)
+	}
+
+	log.Debugf("created role %s", roleName)
+
+	// create instance profile
+	instanceProfileOutput, err := s.IAM.CreateInstanceProfileWithContext(ctx, &iam.CreateInstanceProfileInput{
+		InstanceProfileName: aws.String(roleName),
+		Path:                aws.String("/"),
+	})
+	if err != nil {
+		return nil, ErrCode("failed to create instance profile "+roleName, err)
+	}
+
+	// append instance profile delete to rollback tasks
+	rbfunc = func() error {
+		return func() error {
+			if _, err := s.IAM.DeleteInstanceProfileWithContext(ctx, &iam.DeleteInstanceProfileInput{InstanceProfileName: aws.String(roleName)}); err != nil {
+				return err
+			}
+			return nil
+		}()
+	}
+	rollBackTasks = append(rollBackTasks, rbfunc)
+
+	// add role to instance profile
+	_, err = s.IAM.AddRoleToInstanceProfileWithContext(ctx, &iam.AddRoleToInstanceProfileInput{
+		InstanceProfileName: aws.String(roleName),
+		RoleName:            aws.String(roleName),
+	})
+	if err != nil {
+		return nil, ErrCode("failed to add role to instance profile "+roleName, err)
+	}
+
+	log.Debugf("created instance profile %s", roleName)
+
+	output := &dataset.Access{
+		"policy_arn":            aws.StringValue(policyOutput.Policy.Arn),
+		"policy_name":           aws.StringValue(policyOutput.Policy.PolicyName),
+		"role_arn":              aws.StringValue(roleOutput.Role.Arn),
+		"role_name":             aws.StringValue(roleOutput.Role.RoleName),
+		"instance_profile_arn":  aws.StringValue(instanceProfileOutput.InstanceProfile.Arn),
+		"instance_profile_name": aws.StringValue(instanceProfileOutput.InstanceProfile.InstanceProfileName),
+	}
+
+	return output, nil
+}
+
+// RevokeAccess removes access to the data repository
+func (s *S3Repository) RevokeAccess(ctx context.Context, id string) error {
+	if id == "" {
+		return apierror.New(apierror.ErrBadRequest, "invalid input", errors.New("empty id"))
+	}
+
+	name := id
+	if s.NamePrefix != "" {
+		name = s.NamePrefix + "-" + name
+	}
+
+	outputError := false
+	roleName := fmt.Sprintf("roleDataset_%s", id)
+
+	log.Infof("revoking access to s3datarepository: %s", name)
+
+	// get list of policies attached to the IAM role for this repository
+	policies, err := s.IAM.ListAttachedRolePoliciesWithContext(ctx, &iam.ListAttachedRolePoliciesInput{RoleName: aws.String(roleName)})
+	if err != nil {
+		outputError = true
+		log.Warnf("failed to list policies attached to role %s: %s", roleName, err)
+	}
+
+	// detach and delete all associated policies
+	if policies != nil {
+		for _, p := range policies.AttachedPolicies {
+			if _, err = s.IAM.DetachRolePolicyWithContext(ctx, &iam.DetachRolePolicyInput{
+				PolicyArn: p.PolicyArn,
+				RoleName:  aws.String(roleName),
+			}); err != nil {
+				outputError = true
+				log.Warnf("failed to detach policy %s: %s", aws.StringValue(p.PolicyArn), err)
+			}
+
+			if _, err = s.IAM.DeletePolicyWithContext(ctx, &iam.DeletePolicyInput{PolicyArn: p.PolicyArn}); err != nil {
+				outputError = true
+				log.Warnf("failed to delete policy %s: %s", aws.StringValue(p.PolicyArn), err)
+			}
+		}
+	}
+
+	// remove the role from the instance profile
+	_, err = s.IAM.RemoveRoleFromInstanceProfileWithContext(ctx, &iam.RemoveRoleFromInstanceProfileInput{
+		InstanceProfileName: aws.String(roleName),
+		RoleName:            aws.String(roleName),
+	})
+	if err != nil {
+		outputError = true
+		log.Warnf("failed to remove role from instance profile %s: %s", roleName, err)
+	}
+
+	// delete the IAM instance profile (has the same name as the role)
+	_, err = s.IAM.DeleteInstanceProfileWithContext(ctx, &iam.DeleteInstanceProfileInput{InstanceProfileName: aws.String(roleName)})
+	if err != nil {
+		outputError = true
+		log.Warnf("failed to delete instance profile %s: %s", roleName, err)
+	}
+
+	// delete the IAM role
+	_, err = s.IAM.DeleteRoleWithContext(ctx, &iam.DeleteRoleInput{RoleName: aws.String(roleName)})
+	if err != nil {
+		outputError = true
+		log.Warnf("failed to delete role %s: %s", roleName, err)
+	}
+
+	if outputError {
+		return apierror.New(apierror.ErrInternalError, "one or more errors trying to revoke access for data repository "+name, errors.New("revoke access failure"))
+	}
+
+	return nil
+}
+
+// GrantTemporaryAccess sets up temporary (user) access to the repository
+// TODO: Finish this
+func (s *S3Repository) GrantTemporaryAccess(ctx context.Context, id string) (*dataset.Access, error) {
+	if id == "" {
+		return nil, apierror.New(apierror.ErrBadRequest, "invalid input", errors.New("empty id"))
+	}
+
+	name := id
+	if s.NamePrefix != "" {
+		name = s.NamePrefix + "-" + name
+	}
+
+	log.Debugf("granting temporary access to s3datarepository: %s", name)
+
+	policyName := fmt.Sprintf("%s-TempPlc", name)
+	policyDoc, err := s.temporaryAccessPolicy(name)
+	if err != nil {
+		return nil, ErrCode("failed to generate temporary IAM policy for bucket "+name, err)
+	}
+
+	log.Debugf("creating temporary access policy for bucket '%s'", name)
+
+	// setup rollback function list and defer execution
+	var rollBackTasks []func() error
+	defer func() {
+		if err != nil {
+			log.Errorf("recovering from error granting access to s3datarepository: %s, executing %d rollback tasks", err, len(rollBackTasks))
+			rollBack(&rollBackTasks)
+		}
+	}()
+
+	policyOutput, err := s.IAM.CreatePolicyWithContext(ctx, &iam.CreatePolicyInput{
+		Description:    aws.String(fmt.Sprintf("Temporary policy for bucket %s", name)),
+		PolicyDocument: aws.String(string(policyDoc)),
+		PolicyName:     aws.String(policyName),
+	})
+	if err != nil {
+		return nil, ErrCode("failed to create temporary IAM policy", err)
+	}
+
+	// append policy delete to rollback tasks
+	rollBackTasks = append(rollBackTasks, func() error {
+		return func() error {
+			if _, err := s.IAM.DeletePolicyWithContext(ctx, &iam.DeletePolicyInput{PolicyArn: policyOutput.Policy.Arn}); err != nil {
+				return err
+			}
+			return nil
+		}()
+	})
+
+	// TODO: create group/user and attach policy, generate key
+
+	output := &dataset.Access{}
+
+	return output, nil
+}
+
+// assumeRolePolicy defines the IAM policy for assuming a role
+func (s *S3Repository) assumeRolePolicy(bucket string) ([]byte, error) {
+	log.Debugf("generating assume role policy for %s", bucket)
+
+	policyDoc, err := json.Marshal(PolicyDoc{
+		Version: "2012-10-17",
+		Statement: []PolicyStatement{
+			PolicyStatement{
+				Effect: "Allow",
+				Action: []string{"sts:AssumeRole"},
+				Principal: map[string][]string{
+					"Service": {"ec2.amazonaws.com"},
+				},
+			},
+		}})
+
+	if err != nil {
+		log.Errorf("failed to generate assume role policy for %s: %s", bucket, err)
+		return []byte{}, err
+	}
+
+	log.Debugf("generated assume role policy with document %s", string(policyDoc))
+
+	return policyDoc, nil
+}
+
+// derivativeAccessPolicy defines the IAM policy for access to a derivative dataset (RW)
+func (s *S3Repository) derivativeAccessPolicy(bucket string) ([]byte, error) {
+	log.Debugf("generating derivative bucket access policy for %s", bucket)
+
+	policyDoc, err := json.Marshal(PolicyDoc{
+		Version: "2012-10-17",
+		Statement: []PolicyStatement{
+			PolicyStatement{
+				Resource: []string{fmt.Sprintf("arn:aws:s3:::%s", bucket)},
+				Effect:   "Allow",
+				Action:   []string{"s3:ListBucket"},
+			},
+			PolicyStatement{
+				Resource: []string{fmt.Sprintf("arn:aws:s3:::%s/*", bucket)},
+				Effect:   "Allow",
+				Action: []string{
+					"s3:DeleteObject",
+					"s3:GetObject",
+					"s3:PutObject",
+				},
+			},
+		},
+	})
+
+	if err != nil {
+		log.Errorf("failed to generate derivative bucket access policy for %s: %s", bucket, err)
+		return []byte{}, err
+	}
+
+	log.Debugf("generated policy with document %s", string(policyDoc))
+
+	return policyDoc, nil
+}
+
+// originalAccessPolicy defines the IAM policy for access to an original dataset (RO)
+func (s *S3Repository) originalAccessPolicy(bucket string) ([]byte, error) {
+	log.Debugf("generating original bucket access policy for %s", bucket)
+
+	policyDoc, err := json.Marshal(PolicyDoc{
+		Version: "2012-10-17",
+		Statement: []PolicyStatement{
+			PolicyStatement{
+				Resource: []string{fmt.Sprintf("arn:aws:s3:::%s", bucket)},
+				Effect:   "Allow",
+				Action:   []string{"s3:ListBucket"},
+			},
+			PolicyStatement{
+				Resource: []string{fmt.Sprintf("arn:aws:s3:::%s/*", bucket)},
+				Effect:   "Allow",
+				Action:   []string{"s3:GetObject"},
+			},
+		},
+	})
+
+	if err != nil {
+		log.Errorf("failed to generate original bucket access policy for %s: %s", bucket, err)
+		return []byte{}, err
+	}
+
+	log.Debugf("generated policy with document %s", string(policyDoc))
+
+	return policyDoc, nil
+}
+
+// temporaryAccessPolicy defines the IAM policy for temporary (user) access to upload data (RW)
+func (s *S3Repository) temporaryAccessPolicy(bucket string) ([]byte, error) {
+	log.Debugf("generating temporary bucket access policy for %s", bucket)
+
+	policyDoc, err := json.Marshal(PolicyDoc{
+		Version: "2012-10-17",
+		Statement: []PolicyStatement{
+			PolicyStatement{
+				Resource: []string{fmt.Sprintf("arn:aws:s3:::%s", bucket)},
+				Effect:   "Allow",
+				Action: []string{
+					"s3:ListBucket",
+				},
+			},
+			PolicyStatement{
+				Resource: []string{fmt.Sprintf("arn:aws:s3:::%s/*", bucket)},
+				Effect:   "Allow",
+				Action: []string{
+					"s3:DeleteObject",
+					"s3:GetObject",
+					"s3:PutObject",
+				},
+			},
+		},
+	})
+
+	if err != nil {
+		log.Errorf("failed to generate temporary bucket access policy for %s: %s", bucket, err)
+		return []byte{}, err
+	}
+
+	log.Debugf("generated policy with document %s", string(policyDoc))
+
+	return policyDoc, nil
+}

--- a/s3datarepository/iam_test.go
+++ b/s3datarepository/iam_test.go
@@ -147,7 +147,7 @@ func TestGrantAccess(t *testing.T) {
 	// test success, derivative false
 	s := S3Repository{NamePrefix: "dataset", IAMPathPrefix: "/test/", S3: newMockS3Client(t), IAM: newMockIAMClient(t)}
 	id = "78DAFEF1-E4D3-48E5-A45C-6E3CA0161F08"
-	expected := &dataset.Access{
+	expected := dataset.Access{
 		"policy_arn":            fmt.Sprintf("arn:aws:iam::12345678910:policy/test/dataset-%s-OriginalPlc", id),
 		"policy_name":           fmt.Sprintf("dataset-%s-OriginalPlc", id),
 		"role_arn":              fmt.Sprintf("arn:aws:iam::12345678910:role/test/roleDataset_%s", id),
@@ -167,7 +167,7 @@ func TestGrantAccess(t *testing.T) {
 	// test success, derivative true
 	s = S3Repository{NamePrefix: "dataset", IAMPathPrefix: "/test/", S3: newMockS3Client(t), IAM: newMockIAMClient(t)}
 	id = "78DAFEF1-E4D3-48E5-A45C-6E3CA0161F08"
-	expected = &dataset.Access{
+	expected = dataset.Access{
 		"policy_arn":            fmt.Sprintf("arn:aws:iam::12345678910:policy/test/dataset-%s-DerivativePlc", id),
 		"policy_name":           fmt.Sprintf("dataset-%s-DerivativePlc", id),
 		"role_arn":              fmt.Sprintf("arn:aws:iam::12345678910:role/test/roleDataset_%s", id),

--- a/s3datarepository/iam_test.go
+++ b/s3datarepository/iam_test.go
@@ -13,7 +13,22 @@ import (
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/aws/request"
 	"github.com/aws/aws-sdk-go/service/iam"
+	"github.com/aws/aws-sdk-go/service/iam/iamiface"
 )
+
+// mockIAMClient is a fake IAM client
+type mockIAMClient struct {
+	iamiface.IAMAPI
+	t   *testing.T
+	err map[string]error
+}
+
+func newMockIAMClient(t *testing.T) iamiface.IAMAPI {
+	return &mockIAMClient{
+		t:   t,
+		err: make(map[string]error),
+	}
+}
 
 func (i *mockIAMClient) AddRoleToInstanceProfileWithContext(ctx context.Context, input *iam.AddRoleToInstanceProfileInput, opts ...request.Option) (*iam.AddRoleToInstanceProfileOutput, error) {
 	if err, ok := i.err["AddRoleToInstanceProfileWithContext"]; ok {

--- a/s3datarepository/iam_test.go
+++ b/s3datarepository/iam_test.go
@@ -1,0 +1,397 @@
+package s3datarepository
+
+import (
+	"context"
+	"fmt"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/YaleSpinup/ds-api/apierror"
+	"github.com/YaleSpinup/ds-api/dataset"
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/aws/aws-sdk-go/aws/request"
+	"github.com/aws/aws-sdk-go/service/iam"
+)
+
+func (i *mockIAMClient) AddRoleToInstanceProfileWithContext(ctx context.Context, input *iam.AddRoleToInstanceProfileInput, opts ...request.Option) (*iam.AddRoleToInstanceProfileOutput, error) {
+	if err, ok := i.err["AddRoleToInstanceProfileWithContext"]; ok {
+		return nil, err
+	}
+	return &iam.AddRoleToInstanceProfileOutput{}, nil
+}
+
+func (i *mockIAMClient) AttachRolePolicyWithContext(ctx context.Context, input *iam.AttachRolePolicyInput, opts ...request.Option) (*iam.AttachRolePolicyOutput, error) {
+	if err, ok := i.err["AttachRolePolicyWithContext"]; ok {
+		return nil, err
+	}
+	return &iam.AttachRolePolicyOutput{}, nil
+}
+
+func (i *mockIAMClient) CreateInstanceProfileWithContext(ctx context.Context, input *iam.CreateInstanceProfileInput, opts ...request.Option) (*iam.CreateInstanceProfileOutput, error) {
+	if err, ok := i.err["CreateInstanceProfileWithContext"]; ok {
+		return nil, err
+	}
+
+	output := &iam.CreateInstanceProfileOutput{InstanceProfile: &iam.InstanceProfile{
+		Arn:                 aws.String(fmt.Sprintf("arn:aws:iam::12345678910:instanceprofile/%s", *input.InstanceProfileName)),
+		CreateDate:          &testTime,
+		Path:                input.Path,
+		InstanceProfileId:   aws.String(strings.ToUpper(fmt.Sprintf("%sID123", *input.InstanceProfileName))),
+		InstanceProfileName: input.InstanceProfileName,
+	}}
+
+	return output, nil
+}
+
+func (i *mockIAMClient) CreatePolicyWithContext(ctx context.Context, input *iam.CreatePolicyInput, opts ...request.Option) (*iam.CreatePolicyOutput, error) {
+	if err, ok := i.err["CreatePolicyWithContext"]; ok {
+		return nil, err
+	}
+
+	output := &iam.Policy{
+		Arn:                           aws.String(fmt.Sprintf("arn:aws:iam::12345678910:policy/%s", *input.PolicyName)),
+		AttachmentCount:               aws.Int64(0),
+		CreateDate:                    &testTime,
+		DefaultVersionId:              aws.String("v1"),
+		Description:                   aws.String("policy thang"),
+		IsAttachable:                  aws.Bool(true),
+		Path:                          aws.String("/"),
+		PermissionsBoundaryUsageCount: aws.Int64(0),
+		PolicyId:                      aws.String("TESTPOLICYID123"),
+		PolicyName:                    input.PolicyName,
+		UpdateDate:                    &testTime,
+	}
+
+	return &iam.CreatePolicyOutput{Policy: output}, nil
+}
+
+func (i *mockIAMClient) CreateRoleWithContext(ctx context.Context, input *iam.CreateRoleInput, opts ...request.Option) (*iam.CreateRoleOutput, error) {
+	if err, ok := i.err["CreateRoleWithContext"]; ok {
+		return nil, err
+	}
+
+	output := &iam.CreateRoleOutput{Role: &iam.Role{
+		Arn:         aws.String(fmt.Sprintf("arn:aws:iam::12345678910:role/%s", *input.RoleName)),
+		CreateDate:  &testTime,
+		Description: input.Description,
+		Path:        input.Path,
+		RoleId:      aws.String(strings.ToUpper(fmt.Sprintf("%sID123", *input.RoleName))),
+		RoleName:    input.RoleName,
+	}}
+
+	return output, nil
+}
+
+func (i *mockIAMClient) DeleteInstanceProfileWithContext(ctx context.Context, input *iam.DeleteInstanceProfileInput, opts ...request.Option) (*iam.DeleteInstanceProfileOutput, error) {
+	if err, ok := i.err["DeleteInstanceProfileWithContext"]; ok {
+		return nil, err
+	}
+	return &iam.DeleteInstanceProfileOutput{}, nil
+}
+
+func (i *mockIAMClient) DeletePolicyWithContext(ctx context.Context, input *iam.DeletePolicyInput, opts ...request.Option) (*iam.DeletePolicyOutput, error) {
+	if err, ok := i.err["DeletePolicyWithContext"]; ok {
+		return nil, err
+	}
+	return &iam.DeletePolicyOutput{}, nil
+}
+
+func (i *mockIAMClient) DeleteRoleWithContext(ctx context.Context, input *iam.DeleteRoleInput, opts ...request.Option) (*iam.DeleteRoleOutput, error) {
+	if err, ok := i.err["DeleteRoleWithContext"]; ok {
+		return nil, err
+	}
+	return &iam.DeleteRoleOutput{}, nil
+}
+
+func (i *mockIAMClient) ListAttachedRolePoliciesWithContext(ctx context.Context, input *iam.ListAttachedRolePoliciesInput, opts ...request.Option) (*iam.ListAttachedRolePoliciesOutput, error) {
+	if err, ok := i.err["ListAttachedRolePoliciesWithContext"]; ok {
+		return nil, err
+	}
+	return &iam.ListAttachedRolePoliciesOutput{}, nil
+}
+
+func (i *mockIAMClient) RemoveRoleFromInstanceProfileWithContext(ctx context.Context, input *iam.RemoveRoleFromInstanceProfileInput, opts ...request.Option) (*iam.RemoveRoleFromInstanceProfileOutput, error) {
+	if err, ok := i.err["RemoveRoleFromInstanceProfileWithContext"]; ok {
+		return nil, err
+	}
+	return &iam.RemoveRoleFromInstanceProfileOutput{}, nil
+}
+
+func TestGrantAccess(t *testing.T) {
+	var expectedCode, expectedMessage, id string
+
+	// test success, derivative false
+	s := S3Repository{NamePrefix: "dataset", S3: newMockS3Client(t), IAM: newMockIAMClient(t)}
+	id = "78DAFEF1-E4D3-48E5-A45C-6E3CA0161F08"
+	expected := &dataset.Access{
+		"policy_arn":            fmt.Sprintf("arn:aws:iam::12345678910:policy/dataset-%s-OriginalPlc", id),
+		"policy_name":           fmt.Sprintf("dataset-%s-OriginalPlc", id),
+		"role_arn":              fmt.Sprintf("arn:aws:iam::12345678910:role/roleDataset_%s", id),
+		"role_name":             fmt.Sprintf("roleDataset_%s", id),
+		"instance_profile_arn":  fmt.Sprintf("arn:aws:iam::12345678910:instanceprofile/roleDataset_%s", id),
+		"instance_profile_name": fmt.Sprintf("roleDataset_%s", id),
+	}
+
+	got, err := s.GrantAccess(context.TODO(), id, false)
+	if err != nil {
+		t.Errorf("expected nil error, got: %s", err)
+	}
+	if !reflect.DeepEqual(got, expected) {
+		t.Errorf("expected output:\n%+v, got:\n%+v", expected, got)
+	}
+
+	// test success, derivative true
+	s = S3Repository{NamePrefix: "dataset", S3: newMockS3Client(t), IAM: newMockIAMClient(t)}
+	id = "78DAFEF1-E4D3-48E5-A45C-6E3CA0161F08"
+	expected = &dataset.Access{
+		"policy_arn":            fmt.Sprintf("arn:aws:iam::12345678910:policy/dataset-%s-DerivativePlc", id),
+		"policy_name":           fmt.Sprintf("dataset-%s-DerivativePlc", id),
+		"role_arn":              fmt.Sprintf("arn:aws:iam::12345678910:role/roleDataset_%s", id),
+		"role_name":             fmt.Sprintf("roleDataset_%s", id),
+		"instance_profile_arn":  fmt.Sprintf("arn:aws:iam::12345678910:instanceprofile/roleDataset_%s", id),
+		"instance_profile_name": fmt.Sprintf("roleDataset_%s", id),
+	}
+
+	got, err = s.GrantAccess(context.TODO(), id, true)
+	if err != nil {
+		t.Errorf("expected nil error, got: %s", err)
+	}
+	if !reflect.DeepEqual(got, expected) {
+		t.Errorf("expected output:\n%+v, got:\n%+v", expected, got)
+	}
+
+	// test empty id
+	s = S3Repository{NamePrefix: "dataset", S3: newMockS3Client(t), IAM: newMockIAMClient(t)}
+	_, err = s.GrantAccess(context.TODO(), "", false)
+	if aerr, ok := err.(apierror.Error); ok {
+		if aerr.Code != apierror.ErrBadRequest {
+			t.Errorf("expected error code %s, got: %s", apierror.ErrBadRequest, aerr.Code)
+		}
+	} else {
+		t.Errorf("expected apierror.Error, got: %s", reflect.TypeOf(err).String())
+	}
+
+	// test create policy failure
+	s = S3Repository{NamePrefix: "dataset", S3: newMockS3Client(t), IAM: newMockIAMClient(t)}
+	id = "78DAFEF1-E4D3-48E5-A45C-6E3CA0161F08"
+	expectedCode = apierror.ErrServiceUnavailable
+	expectedMessage = fmt.Sprintf("failed to create IAM policy")
+	s.IAM.(*mockIAMClient).err["CreatePolicyWithContext"] = awserr.New("InternalError", "Internal Error", nil)
+
+	_, err = s.GrantAccess(context.TODO(), id, false)
+	if err == nil {
+		t.Error("expected error, got: nil")
+	} else {
+		if aerr, ok := err.(apierror.Error); ok {
+			if aerr.Code != expectedCode {
+				t.Errorf("expected error code %s, got: %s", expectedCode, aerr.Code)
+			}
+			if aerr.Message != expectedMessage {
+				t.Errorf("expected error message '%s', got: '%s'", expectedMessage, aerr.Message)
+			}
+		} else {
+			t.Errorf("expected apierror.Error, got: %s", reflect.TypeOf(err).String())
+		}
+	}
+
+	// test create role failure
+	s = S3Repository{NamePrefix: "dataset", S3: newMockS3Client(t), IAM: newMockIAMClient(t)}
+	id = "78DAFEF1-E4D3-48E5-A45C-6E3CA0161F08"
+	expectedCode = apierror.ErrServiceUnavailable
+	expectedMessage = fmt.Sprintf("failed to create IAM role roleDataset_%s", id)
+	s.IAM.(*mockIAMClient).err["CreateRoleWithContext"] = awserr.New("InternalError", "Internal Error", nil)
+
+	_, err = s.GrantAccess(context.TODO(), id, false)
+	if err == nil {
+		t.Error("expected error, got: nil")
+	} else {
+		if aerr, ok := err.(apierror.Error); ok {
+			if aerr.Code != expectedCode {
+				t.Errorf("expected error code %s, got: %s", expectedCode, aerr.Code)
+			}
+			if aerr.Message != expectedMessage {
+				t.Errorf("expected error message '%s', got: '%s'", expectedMessage, aerr.Message)
+			}
+		} else {
+			t.Errorf("expected apierror.Error, got: %s", reflect.TypeOf(err).String())
+		}
+	}
+
+	// test attach role policy failure
+	s = S3Repository{NamePrefix: "dataset", S3: newMockS3Client(t), IAM: newMockIAMClient(t)}
+	id = "78DAFEF1-E4D3-48E5-A45C-6E3CA0161F08"
+	expectedCode = apierror.ErrServiceUnavailable
+	expectedMessage = fmt.Sprintf("failed to attach policy to role roleDataset_%s", id)
+	s.IAM.(*mockIAMClient).err["AttachRolePolicyWithContext"] = awserr.New("InternalError", "Internal Error", nil)
+
+	_, err = s.GrantAccess(context.TODO(), id, false)
+	if err == nil {
+		t.Error("expected error, got: nil")
+	} else {
+		if aerr, ok := err.(apierror.Error); ok {
+			if aerr.Code != expectedCode {
+				t.Errorf("expected error code %s, got: %s", expectedCode, aerr.Code)
+			}
+			if aerr.Message != expectedMessage {
+				t.Errorf("expected error message '%s', got: '%s'", expectedMessage, aerr.Message)
+			}
+		} else {
+			t.Errorf("expected apierror.Error, got: %s", reflect.TypeOf(err).String())
+		}
+	}
+
+	// test create instance profile failure
+	s = S3Repository{NamePrefix: "dataset", S3: newMockS3Client(t), IAM: newMockIAMClient(t)}
+	id = "78DAFEF1-E4D3-48E5-A45C-6E3CA0161F08"
+	expectedCode = apierror.ErrServiceUnavailable
+	expectedMessage = fmt.Sprintf("failed to create instance profile roleDataset_%s", id)
+	s.IAM.(*mockIAMClient).err["CreateInstanceProfileWithContext"] = awserr.New("InternalError", "Internal Error", nil)
+
+	_, err = s.GrantAccess(context.TODO(), id, false)
+	if err == nil {
+		t.Error("expected error, got: nil")
+	} else {
+		if aerr, ok := err.(apierror.Error); ok {
+			if aerr.Code != expectedCode {
+				t.Errorf("expected error code %s, got: %s", expectedCode, aerr.Code)
+			}
+			if aerr.Message != expectedMessage {
+				t.Errorf("expected error message '%s', got: '%s'", expectedMessage, aerr.Message)
+			}
+		} else {
+			t.Errorf("expected apierror.Error, got: %s", reflect.TypeOf(err).String())
+		}
+	}
+
+	// test add role to instance profile failure
+	s = S3Repository{NamePrefix: "dataset", S3: newMockS3Client(t), IAM: newMockIAMClient(t)}
+	id = "78DAFEF1-E4D3-48E5-A45C-6E3CA0161F08"
+	expectedCode = apierror.ErrServiceUnavailable
+	expectedMessage = fmt.Sprintf("failed to add role to instance profile roleDataset_%s", id)
+	s.IAM.(*mockIAMClient).err["AddRoleToInstanceProfileWithContext"] = awserr.New("InternalError", "Internal Error", nil)
+
+	_, err = s.GrantAccess(context.TODO(), id, false)
+	if err == nil {
+		t.Error("expected error, got: nil")
+	} else {
+		if aerr, ok := err.(apierror.Error); ok {
+			if aerr.Code != expectedCode {
+				t.Errorf("expected error code %s, got: %s", expectedCode, aerr.Code)
+			}
+			if aerr.Message != expectedMessage {
+				t.Errorf("expected error message '%s', got: '%s'", expectedMessage, aerr.Message)
+			}
+		} else {
+			t.Errorf("expected apierror.Error, got: %s", reflect.TypeOf(err).String())
+		}
+	}
+
+}
+
+func TestRevokeAccess(t *testing.T) {
+	var expectedCode, expectedMessage, id string
+
+	// test success
+	s := S3Repository{NamePrefix: "dataset", S3: newMockS3Client(t), IAM: newMockIAMClient(t)}
+	id = "78DAFEF1-E4D3-48E5-A45C-6E3CA0161F08"
+	err := s.RevokeAccess(context.TODO(), id)
+	if err != nil {
+		t.Errorf("expected nil error, got: %s", err)
+	}
+
+	// test empty id
+	s = S3Repository{NamePrefix: "dataset", S3: newMockS3Client(t), IAM: newMockIAMClient(t)}
+	err = s.RevokeAccess(context.TODO(), "")
+	if aerr, ok := err.(apierror.Error); ok {
+		if aerr.Code != apierror.ErrBadRequest {
+			t.Errorf("expected error code %s, got: %s", apierror.ErrBadRequest, aerr.Code)
+		}
+	} else {
+		t.Errorf("expected apierror.Error, got: %s", reflect.TypeOf(err).String())
+	}
+
+	expectedCode = apierror.ErrInternalError
+	expectedMessage = fmt.Sprintf("one or more errors trying to revoke access for data repository dataset-%s", id)
+
+	// test list role policies failure
+	s = S3Repository{NamePrefix: "dataset", S3: newMockS3Client(t), IAM: newMockIAMClient(t)}
+	s.IAM.(*mockIAMClient).err["ListAttachedRolePoliciesWithContext"] = awserr.New("InternalError", "Internal Error", nil)
+
+	err = s.RevokeAccess(context.TODO(), id)
+	if err == nil {
+		t.Error("expected error, got: nil")
+	} else {
+		if aerr, ok := err.(apierror.Error); ok {
+			if aerr.Code != expectedCode {
+				t.Errorf("expected error code %s, got: %s", expectedCode, aerr.Code)
+			}
+			if aerr.Message != expectedMessage {
+				t.Errorf("expected error message '%s', got: '%s'", expectedMessage, aerr.Message)
+			}
+		} else {
+			t.Errorf("expected apierror.Error, got: %s", reflect.TypeOf(err).String())
+		}
+	}
+
+	// test remove role from instance profile failure
+	s = S3Repository{NamePrefix: "dataset", S3: newMockS3Client(t), IAM: newMockIAMClient(t)}
+	s.IAM.(*mockIAMClient).err["RemoveRoleFromInstanceProfileWithContext"] = awserr.New("InternalError", "Internal Error", nil)
+
+	err = s.RevokeAccess(context.TODO(), id)
+	if err == nil {
+		t.Error("expected error, got: nil")
+	} else {
+		if aerr, ok := err.(apierror.Error); ok {
+			if aerr.Code != expectedCode {
+				t.Errorf("expected error code %s, got: %s", expectedCode, aerr.Code)
+			}
+			if aerr.Message != expectedMessage {
+				t.Errorf("expected error message '%s', got: '%s'", expectedMessage, aerr.Message)
+			}
+		} else {
+			t.Errorf("expected apierror.Error, got: %s", reflect.TypeOf(err).String())
+		}
+	}
+
+	// test delete instance profile failure
+	s = S3Repository{NamePrefix: "dataset", S3: newMockS3Client(t), IAM: newMockIAMClient(t)}
+	s.IAM.(*mockIAMClient).err["DeleteInstanceProfileWithContext"] = awserr.New("InternalError", "Internal Error", nil)
+
+	err = s.RevokeAccess(context.TODO(), id)
+	if err == nil {
+		t.Error("expected error, got: nil")
+	} else {
+		if aerr, ok := err.(apierror.Error); ok {
+			if aerr.Code != expectedCode {
+				t.Errorf("expected error code %s, got: %s", expectedCode, aerr.Code)
+			}
+			if aerr.Message != expectedMessage {
+				t.Errorf("expected error message '%s', got: '%s'", expectedMessage, aerr.Message)
+			}
+		} else {
+			t.Errorf("expected apierror.Error, got: %s", reflect.TypeOf(err).String())
+		}
+	}
+
+	// test delete role failure
+	s = S3Repository{NamePrefix: "dataset", S3: newMockS3Client(t), IAM: newMockIAMClient(t)}
+	s.IAM.(*mockIAMClient).err["DeleteRoleWithContext"] = awserr.New("InternalError", "Internal Error", nil)
+
+	err = s.RevokeAccess(context.TODO(), id)
+	if err == nil {
+		t.Error("expected error, got: nil")
+	} else {
+		if aerr, ok := err.(apierror.Error); ok {
+			if aerr.Code != expectedCode {
+				t.Errorf("expected error code %s, got: %s", expectedCode, aerr.Code)
+			}
+			if aerr.Message != expectedMessage {
+				t.Errorf("expected error message '%s', got: '%s'", expectedMessage, aerr.Message)
+			}
+		} else {
+			t.Errorf("expected apierror.Error, got: %s", reflect.TypeOf(err).String())
+		}
+	}
+}

--- a/s3datarepository/s3datarepository.go
+++ b/s3datarepository/s3datarepository.go
@@ -25,10 +25,11 @@ type S3RepositoryOption func(*S3Repository)
 
 // S3Repository is an implementation of a data respository in S3
 type S3Repository struct {
-	NamePrefix string
-	IAM        iamiface.IAMAPI
-	S3         s3iface.S3API
-	config     *aws.Config
+	NamePrefix    string
+	IAMPathPrefix string
+	IAM           iamiface.IAMAPI
+	S3            s3iface.S3API
+	config        *aws.Config
 }
 
 // NewDefaultRepository creates a new repository from the default config data
@@ -65,6 +66,9 @@ func NewDefaultRepository(config map[string]interface{}) (*S3Repository, error) 
 	if endpoint != "" {
 		opts = append(opts, WithEndpoint(endpoint))
 	}
+
+	// set default IAMPathPrefix
+	opts = append(opts, WithIAMPathPrefix("/spinup/dataset/"))
 
 	return New(opts...)
 }
@@ -108,6 +112,14 @@ func WithEndpoint(endpoint string) S3RepositoryOption {
 	return func(s *S3Repository) {
 		log.Debugf("setting endpoint %s", endpoint)
 		s.config.WithEndpoint(endpoint)
+	}
+}
+
+// WithIAMPathPrefix sets the IAMPathPrefix for the S3Repository
+// This is used as the Path prefix for IAM resources
+func WithIAMPathPrefix(prefix string) S3RepositoryOption {
+	return func(s *S3Repository) {
+		s.IAMPathPrefix = prefix
 	}
 }
 

--- a/s3datarepository/s3datarepository_test.go
+++ b/s3datarepository/s3datarepository_test.go
@@ -102,6 +102,8 @@ func TestNewDefaultRepository(t *testing.T) {
 		"endpoint": "https://under.mydesk.amazonaws.com",
 	}
 
+	expectedIAMPathPrefix := "/spinup/dataset/"
+
 	s, err := NewDefaultRepository(testConfig)
 	if err != nil {
 		t.Errorf("expected nil error, got: %s", err)
@@ -121,6 +123,10 @@ func TestNewDefaultRepository(t *testing.T) {
 
 	if s.config.Endpoint == nil {
 		t.Error("expected config Endpoint to be set, got nil")
+	}
+
+	if s.IAMPathPrefix != expectedIAMPathPrefix {
+		t.Errorf("expected IAMPathPrefix to be '%s', got '%s'", expectedIAMPathPrefix, s.IAMPathPrefix)
 	}
 }
 

--- a/s3datarepository/s3datarepository_test.go
+++ b/s3datarepository/s3datarepository_test.go
@@ -14,7 +14,6 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/aws/request"
-	"github.com/aws/aws-sdk-go/service/iam/iamiface"
 	"github.com/aws/aws-sdk-go/service/s3"
 	"github.com/aws/aws-sdk-go/service/s3/s3iface"
 )
@@ -32,20 +31,6 @@ func newMockS3Client(t *testing.T) s3iface.S3API {
 		t:         t,
 		err:       make(map[string]error),
 		headCount: 0,
-	}
-}
-
-// mockIAMClient is a fake IAM client
-type mockIAMClient struct {
-	iamiface.IAMAPI
-	t   *testing.T
-	err map[string]error
-}
-
-func newMockIAMClient(t *testing.T) iamiface.IAMAPI {
-	return &mockIAMClient{
-		t:   t,
-		err: make(map[string]error),
 	}
 }
 


### PR DESCRIPTION
This PR adds `GrantAccess` and `RevokeAccess` functions to the `DataRepository` interface. They configure/remove the necessary policies and role in IAM based on the type of dataset (original or derivative).
I've started adding another function `GrantTemporaryAccess` for creating a group/user with a key, however that's not completed yet.
Maybe we should call those `GrantRoleAccess` and `GrantUserAccess` ...