### PR TITLE
Add IAM PathPrefix

### DIFF
--- a/s3datarepository/iam.go
+++ b/s3datarepository/iam.go
@@ -67,8 +67,10 @@ func (s *S3Repository) GrantAccess(ctx context.Context, id string, derivative bo
 		}
 	}()
 
+	// create policy
 	policyOutput, err := s.IAM.CreatePolicyWithContext(ctx, &iam.CreatePolicyInput{
 		Description:    aws.String(fmt.Sprintf("Access policy for bucket %s", name)),
+		Path:           aws.String(s.PathPrefix),
 		PolicyDocument: aws.String(string(policyDoc)),
 		PolicyName:     aws.String(policyName),
 	})
@@ -77,15 +79,14 @@ func (s *S3Repository) GrantAccess(ctx context.Context, id string, derivative bo
 	}
 
 	// append policy delete to rollback tasks
-	rbfunc := func() error {
+	rollBackTasks = append(rollBackTasks, func() error {
 		return func() error {
 			if _, err := s.IAM.DeletePolicyWithContext(ctx, &iam.DeletePolicyInput{PolicyArn: policyOutput.Policy.Arn}); err != nil {
 				return err
 			}
 			return nil
 		}()
-	}
-	rollBackTasks = append(rollBackTasks, rbfunc)
+	})
 
 	// create role
 	roleName := fmt.Sprintf("roleDataset_%s", id)
@@ -99,7 +100,7 @@ func (s *S3Repository) GrantAccess(ctx context.Context, id string, derivative bo
 	roleOutput, err := s.IAM.CreateRoleWithContext(ctx, &iam.CreateRoleInput{
 		AssumeRolePolicyDocument: aws.String(string(roleDoc)),
 		Description:              aws.String(fmt.Sprintf("Role for accessing bucket %s", name)),
-		Path:                     aws.String("/"),
+		Path:                     aws.String(s.PathPrefix),
 		RoleName:                 aws.String(roleName),
 	})
 	if err != nil {
@@ -107,15 +108,14 @@ func (s *S3Repository) GrantAccess(ctx context.Context, id string, derivative bo
 	}
 
 	// append role delete to rollback tasks
-	rbfunc = func() error {
+	rollBackTasks = append(rollBackTasks, func() error {
 		return func() error {
 			if _, err := s.IAM.DeleteRoleWithContext(ctx, &iam.DeleteRoleInput{RoleName: roleOutput.Role.RoleName}); err != nil {
 				return err
 			}
 			return nil
 		}()
-	}
-	rollBackTasks = append(rollBackTasks, rbfunc)
+	})
 
 	// attach access policy to the role
 	_, err = s.IAM.AttachRolePolicyWithContext(ctx, &iam.AttachRolePolicyInput{
@@ -126,27 +126,39 @@ func (s *S3Repository) GrantAccess(ctx context.Context, id string, derivative bo
 		return nil, ErrCode("failed to attach policy to role "+roleName, err)
 	}
 
+	// append policy detach from role to rollback tasks
+	rollBackTasks = append(rollBackTasks, func() error {
+		return func() error {
+			if _, err := s.IAM.DetachRolePolicyWithContext(ctx, &iam.DetachRolePolicyInput{
+				PolicyArn: policyOutput.Policy.Arn,
+				RoleName:  aws.String(roleName),
+			}); err != nil {
+				return err
+			}
+			return nil
+		}()
+	})
+
 	log.Debugf("created role %s", roleName)
 
 	// create instance profile
 	instanceProfileOutput, err := s.IAM.CreateInstanceProfileWithContext(ctx, &iam.CreateInstanceProfileInput{
 		InstanceProfileName: aws.String(roleName),
-		Path:                aws.String("/"),
+		Path:                aws.String(s.PathPrefix),
 	})
 	if err != nil {
 		return nil, ErrCode("failed to create instance profile "+roleName, err)
 	}
 
 	// append instance profile delete to rollback tasks
-	rbfunc = func() error {
+	rollBackTasks = append(rollBackTasks, func() error {
 		return func() error {
 			if _, err := s.IAM.DeleteInstanceProfileWithContext(ctx, &iam.DeleteInstanceProfileInput{InstanceProfileName: aws.String(roleName)}); err != nil {
 				return err
 			}
 			return nil
 		}()
-	}
-	rollBackTasks = append(rollBackTasks, rbfunc)
+	})
 
 	// add role to instance profile
 	_, err = s.IAM.AddRoleToInstanceProfileWithContext(ctx, &iam.AddRoleToInstanceProfileInput{
@@ -156,6 +168,19 @@ func (s *S3Repository) GrantAccess(ctx context.Context, id string, derivative bo
 	if err != nil {
 		return nil, ErrCode("failed to add role to instance profile "+roleName, err)
 	}
+
+	// append role removal from instance profile to rollback tasks
+	rollBackTasks = append(rollBackTasks, func() error {
+		return func() error {
+			if _, err := s.IAM.RemoveRoleFromInstanceProfileWithContext(ctx, &iam.RemoveRoleFromInstanceProfileInput{
+				InstanceProfileName: aws.String(roleName),
+				RoleName:            aws.String(roleName),
+			}); err != nil {
+				return err
+			}
+			return nil
+		}()
+	})
 
 	log.Debugf("created instance profile %s", roleName)
 
@@ -188,7 +213,9 @@ func (s *S3Repository) RevokeAccess(ctx context.Context, id string) error {
 	log.Infof("revoking access to s3datarepository: %s", name)
 
 	// get list of policies attached to the IAM role for this repository
-	policies, err := s.IAM.ListAttachedRolePoliciesWithContext(ctx, &iam.ListAttachedRolePoliciesInput{RoleName: aws.String(roleName)})
+	policies, err := s.IAM.ListAttachedRolePoliciesWithContext(ctx, &iam.ListAttachedRolePoliciesInput{
+		PathPrefix: aws.String(s.PathPrefix),
+		RoleName:   aws.String(roleName)})
 	if err != nil {
 		outputError = true
 		log.Warnf("failed to list policies attached to role %s: %s", roleName, err)
@@ -276,6 +303,7 @@ func (s *S3Repository) GrantTemporaryAccess(ctx context.Context, id string) (*da
 
 	policyOutput, err := s.IAM.CreatePolicyWithContext(ctx, &iam.CreatePolicyInput{
 		Description:    aws.String(fmt.Sprintf("Temporary policy for bucket %s", name)),
+		Path:           aws.String(s.PathPrefix),
 		PolicyDocument: aws.String(string(policyDoc)),
 		PolicyName:     aws.String(policyName),
 	})

--- a/s3datarepository/iam.go
+++ b/s3datarepository/iam.go
@@ -70,7 +70,7 @@ func (s *S3Repository) GrantAccess(ctx context.Context, id string, derivative bo
 	// create policy
 	policyOutput, err := s.IAM.CreatePolicyWithContext(ctx, &iam.CreatePolicyInput{
 		Description:    aws.String(fmt.Sprintf("Access policy for bucket %s", name)),
-		Path:           aws.String(s.PathPrefix),
+		Path:           aws.String(s.IAMPathPrefix),
 		PolicyDocument: aws.String(string(policyDoc)),
 		PolicyName:     aws.String(policyName),
 	})
@@ -100,7 +100,7 @@ func (s *S3Repository) GrantAccess(ctx context.Context, id string, derivative bo
 	roleOutput, err := s.IAM.CreateRoleWithContext(ctx, &iam.CreateRoleInput{
 		AssumeRolePolicyDocument: aws.String(string(roleDoc)),
 		Description:              aws.String(fmt.Sprintf("Role for accessing bucket %s", name)),
-		Path:                     aws.String(s.PathPrefix),
+		Path:                     aws.String(s.IAMPathPrefix),
 		RoleName:                 aws.String(roleName),
 	})
 	if err != nil {
@@ -144,7 +144,7 @@ func (s *S3Repository) GrantAccess(ctx context.Context, id string, derivative bo
 	// create instance profile
 	instanceProfileOutput, err := s.IAM.CreateInstanceProfileWithContext(ctx, &iam.CreateInstanceProfileInput{
 		InstanceProfileName: aws.String(roleName),
-		Path:                aws.String(s.PathPrefix),
+		Path:                aws.String(s.IAMPathPrefix),
 	})
 	if err != nil {
 		return nil, ErrCode("failed to create instance profile "+roleName, err)
@@ -214,7 +214,7 @@ func (s *S3Repository) RevokeAccess(ctx context.Context, id string) error {
 
 	// get list of policies attached to the IAM role for this repository
 	policies, err := s.IAM.ListAttachedRolePoliciesWithContext(ctx, &iam.ListAttachedRolePoliciesInput{
-		PathPrefix: aws.String(s.PathPrefix),
+		PathPrefix: aws.String(s.IAMPathPrefix),
 		RoleName:   aws.String(roleName)})
 	if err != nil {
 		outputError = true
@@ -303,7 +303,7 @@ func (s *S3Repository) GrantTemporaryAccess(ctx context.Context, id string) (*da
 
 	policyOutput, err := s.IAM.CreatePolicyWithContext(ctx, &iam.CreatePolicyInput{
 		Description:    aws.String(fmt.Sprintf("Temporary policy for bucket %s", name)),
-		Path:           aws.String(s.PathPrefix),
+		Path:           aws.String(s.IAMPathPrefix),
 		PolicyDocument: aws.String(string(policyDoc)),
 		PolicyName:     aws.String(policyName),
 	})

--- a/s3datarepository/iam_test.go
+++ b/s3datarepository/iam_test.go
@@ -50,7 +50,7 @@ func (i *mockIAMClient) CreateInstanceProfileWithContext(ctx context.Context, in
 	}
 
 	output := &iam.CreateInstanceProfileOutput{InstanceProfile: &iam.InstanceProfile{
-		Arn:                 aws.String(fmt.Sprintf("arn:aws:iam::12345678910:instanceprofile/%s", *input.InstanceProfileName)),
+		Arn:                 aws.String(fmt.Sprintf("arn:aws:iam::12345678910:instanceprofile%s%s", *input.Path, *input.InstanceProfileName)),
 		CreateDate:          &testTime,
 		Path:                input.Path,
 		InstanceProfileId:   aws.String(strings.ToUpper(fmt.Sprintf("%sID123", *input.InstanceProfileName))),
@@ -66,13 +66,13 @@ func (i *mockIAMClient) CreatePolicyWithContext(ctx context.Context, input *iam.
 	}
 
 	output := &iam.Policy{
-		Arn:                           aws.String(fmt.Sprintf("arn:aws:iam::12345678910:policy/%s", *input.PolicyName)),
+		Arn:                           aws.String(fmt.Sprintf("arn:aws:iam::12345678910:policy%s%s", *input.Path, *input.PolicyName)),
 		AttachmentCount:               aws.Int64(0),
 		CreateDate:                    &testTime,
 		DefaultVersionId:              aws.String("v1"),
 		Description:                   aws.String("policy thang"),
 		IsAttachable:                  aws.Bool(true),
-		Path:                          aws.String("/"),
+		Path:                          input.Path,
 		PermissionsBoundaryUsageCount: aws.Int64(0),
 		PolicyId:                      aws.String("TESTPOLICYID123"),
 		PolicyName:                    input.PolicyName,
@@ -88,7 +88,7 @@ func (i *mockIAMClient) CreateRoleWithContext(ctx context.Context, input *iam.Cr
 	}
 
 	output := &iam.CreateRoleOutput{Role: &iam.Role{
-		Arn:         aws.String(fmt.Sprintf("arn:aws:iam::12345678910:role/%s", *input.RoleName)),
+		Arn:         aws.String(fmt.Sprintf("arn:aws:iam::12345678910:role%s%s", *input.Path, *input.RoleName)),
 		CreateDate:  &testTime,
 		Description: input.Description,
 		Path:        input.Path,
@@ -120,6 +120,13 @@ func (i *mockIAMClient) DeleteRoleWithContext(ctx context.Context, input *iam.De
 	return &iam.DeleteRoleOutput{}, nil
 }
 
+func (i *mockIAMClient) DetachRolePolicyWithContext(ctx context.Context, input *iam.DetachRolePolicyInput, opts ...request.Option) (*iam.DetachRolePolicyOutput, error) {
+	if err, ok := i.err["DetachRolePolicyWithContext"]; ok {
+		return nil, err
+	}
+	return &iam.DetachRolePolicyOutput{}, nil
+}
+
 func (i *mockIAMClient) ListAttachedRolePoliciesWithContext(ctx context.Context, input *iam.ListAttachedRolePoliciesInput, opts ...request.Option) (*iam.ListAttachedRolePoliciesOutput, error) {
 	if err, ok := i.err["ListAttachedRolePoliciesWithContext"]; ok {
 		return nil, err
@@ -138,14 +145,14 @@ func TestGrantAccess(t *testing.T) {
 	var expectedCode, expectedMessage, id string
 
 	// test success, derivative false
-	s := S3Repository{NamePrefix: "dataset", S3: newMockS3Client(t), IAM: newMockIAMClient(t)}
+	s := S3Repository{NamePrefix: "dataset", PathPrefix: "/test/", S3: newMockS3Client(t), IAM: newMockIAMClient(t)}
 	id = "78DAFEF1-E4D3-48E5-A45C-6E3CA0161F08"
 	expected := &dataset.Access{
-		"policy_arn":            fmt.Sprintf("arn:aws:iam::12345678910:policy/dataset-%s-OriginalPlc", id),
+		"policy_arn":            fmt.Sprintf("arn:aws:iam::12345678910:policy/test/dataset-%s-OriginalPlc", id),
 		"policy_name":           fmt.Sprintf("dataset-%s-OriginalPlc", id),
-		"role_arn":              fmt.Sprintf("arn:aws:iam::12345678910:role/roleDataset_%s", id),
+		"role_arn":              fmt.Sprintf("arn:aws:iam::12345678910:role/test/roleDataset_%s", id),
 		"role_name":             fmt.Sprintf("roleDataset_%s", id),
-		"instance_profile_arn":  fmt.Sprintf("arn:aws:iam::12345678910:instanceprofile/roleDataset_%s", id),
+		"instance_profile_arn":  fmt.Sprintf("arn:aws:iam::12345678910:instanceprofile/test/roleDataset_%s", id),
 		"instance_profile_name": fmt.Sprintf("roleDataset_%s", id),
 	}
 
@@ -158,14 +165,14 @@ func TestGrantAccess(t *testing.T) {
 	}
 
 	// test success, derivative true
-	s = S3Repository{NamePrefix: "dataset", S3: newMockS3Client(t), IAM: newMockIAMClient(t)}
+	s = S3Repository{NamePrefix: "dataset", PathPrefix: "/test/", S3: newMockS3Client(t), IAM: newMockIAMClient(t)}
 	id = "78DAFEF1-E4D3-48E5-A45C-6E3CA0161F08"
 	expected = &dataset.Access{
-		"policy_arn":            fmt.Sprintf("arn:aws:iam::12345678910:policy/dataset-%s-DerivativePlc", id),
+		"policy_arn":            fmt.Sprintf("arn:aws:iam::12345678910:policy/test/dataset-%s-DerivativePlc", id),
 		"policy_name":           fmt.Sprintf("dataset-%s-DerivativePlc", id),
-		"role_arn":              fmt.Sprintf("arn:aws:iam::12345678910:role/roleDataset_%s", id),
+		"role_arn":              fmt.Sprintf("arn:aws:iam::12345678910:role/test/roleDataset_%s", id),
 		"role_name":             fmt.Sprintf("roleDataset_%s", id),
-		"instance_profile_arn":  fmt.Sprintf("arn:aws:iam::12345678910:instanceprofile/roleDataset_%s", id),
+		"instance_profile_arn":  fmt.Sprintf("arn:aws:iam::12345678910:instanceprofile/test/roleDataset_%s", id),
 		"instance_profile_name": fmt.Sprintf("roleDataset_%s", id),
 	}
 
@@ -178,7 +185,7 @@ func TestGrantAccess(t *testing.T) {
 	}
 
 	// test empty id
-	s = S3Repository{NamePrefix: "dataset", S3: newMockS3Client(t), IAM: newMockIAMClient(t)}
+	s = S3Repository{NamePrefix: "dataset", PathPrefix: "/test/", S3: newMockS3Client(t), IAM: newMockIAMClient(t)}
 	_, err = s.GrantAccess(context.TODO(), "", false)
 	if aerr, ok := err.(apierror.Error); ok {
 		if aerr.Code != apierror.ErrBadRequest {
@@ -189,7 +196,7 @@ func TestGrantAccess(t *testing.T) {
 	}
 
 	// test create policy failure
-	s = S3Repository{NamePrefix: "dataset", S3: newMockS3Client(t), IAM: newMockIAMClient(t)}
+	s = S3Repository{NamePrefix: "dataset", PathPrefix: "/test/", S3: newMockS3Client(t), IAM: newMockIAMClient(t)}
 	id = "78DAFEF1-E4D3-48E5-A45C-6E3CA0161F08"
 	expectedCode = apierror.ErrServiceUnavailable
 	expectedMessage = fmt.Sprintf("failed to create IAM policy")
@@ -212,7 +219,7 @@ func TestGrantAccess(t *testing.T) {
 	}
 
 	// test create role failure
-	s = S3Repository{NamePrefix: "dataset", S3: newMockS3Client(t), IAM: newMockIAMClient(t)}
+	s = S3Repository{NamePrefix: "dataset", PathPrefix: "/test/", S3: newMockS3Client(t), IAM: newMockIAMClient(t)}
 	id = "78DAFEF1-E4D3-48E5-A45C-6E3CA0161F08"
 	expectedCode = apierror.ErrServiceUnavailable
 	expectedMessage = fmt.Sprintf("failed to create IAM role roleDataset_%s", id)
@@ -235,7 +242,7 @@ func TestGrantAccess(t *testing.T) {
 	}
 
 	// test attach role policy failure
-	s = S3Repository{NamePrefix: "dataset", S3: newMockS3Client(t), IAM: newMockIAMClient(t)}
+	s = S3Repository{NamePrefix: "dataset", PathPrefix: "/test/", S3: newMockS3Client(t), IAM: newMockIAMClient(t)}
 	id = "78DAFEF1-E4D3-48E5-A45C-6E3CA0161F08"
 	expectedCode = apierror.ErrServiceUnavailable
 	expectedMessage = fmt.Sprintf("failed to attach policy to role roleDataset_%s", id)
@@ -258,7 +265,7 @@ func TestGrantAccess(t *testing.T) {
 	}
 
 	// test create instance profile failure
-	s = S3Repository{NamePrefix: "dataset", S3: newMockS3Client(t), IAM: newMockIAMClient(t)}
+	s = S3Repository{NamePrefix: "dataset", PathPrefix: "/test/", S3: newMockS3Client(t), IAM: newMockIAMClient(t)}
 	id = "78DAFEF1-E4D3-48E5-A45C-6E3CA0161F08"
 	expectedCode = apierror.ErrServiceUnavailable
 	expectedMessage = fmt.Sprintf("failed to create instance profile roleDataset_%s", id)
@@ -281,7 +288,7 @@ func TestGrantAccess(t *testing.T) {
 	}
 
 	// test add role to instance profile failure
-	s = S3Repository{NamePrefix: "dataset", S3: newMockS3Client(t), IAM: newMockIAMClient(t)}
+	s = S3Repository{NamePrefix: "dataset", PathPrefix: "/test/", S3: newMockS3Client(t), IAM: newMockIAMClient(t)}
 	id = "78DAFEF1-E4D3-48E5-A45C-6E3CA0161F08"
 	expectedCode = apierror.ErrServiceUnavailable
 	expectedMessage = fmt.Sprintf("failed to add role to instance profile roleDataset_%s", id)
@@ -309,7 +316,7 @@ func TestRevokeAccess(t *testing.T) {
 	var expectedCode, expectedMessage, id string
 
 	// test success
-	s := S3Repository{NamePrefix: "dataset", S3: newMockS3Client(t), IAM: newMockIAMClient(t)}
+	s := S3Repository{NamePrefix: "dataset", PathPrefix: "/test/", S3: newMockS3Client(t), IAM: newMockIAMClient(t)}
 	id = "78DAFEF1-E4D3-48E5-A45C-6E3CA0161F08"
 	err := s.RevokeAccess(context.TODO(), id)
 	if err != nil {
@@ -317,7 +324,7 @@ func TestRevokeAccess(t *testing.T) {
 	}
 
 	// test empty id
-	s = S3Repository{NamePrefix: "dataset", S3: newMockS3Client(t), IAM: newMockIAMClient(t)}
+	s = S3Repository{NamePrefix: "dataset", PathPrefix: "/test/", S3: newMockS3Client(t), IAM: newMockIAMClient(t)}
 	err = s.RevokeAccess(context.TODO(), "")
 	if aerr, ok := err.(apierror.Error); ok {
 		if aerr.Code != apierror.ErrBadRequest {
@@ -331,7 +338,7 @@ func TestRevokeAccess(t *testing.T) {
 	expectedMessage = fmt.Sprintf("one or more errors trying to revoke access for data repository dataset-%s", id)
 
 	// test list role policies failure
-	s = S3Repository{NamePrefix: "dataset", S3: newMockS3Client(t), IAM: newMockIAMClient(t)}
+	s = S3Repository{NamePrefix: "dataset", PathPrefix: "/test/", S3: newMockS3Client(t), IAM: newMockIAMClient(t)}
 	s.IAM.(*mockIAMClient).err["ListAttachedRolePoliciesWithContext"] = awserr.New("InternalError", "Internal Error", nil)
 
 	err = s.RevokeAccess(context.TODO(), id)
@@ -351,7 +358,7 @@ func TestRevokeAccess(t *testing.T) {
 	}
 
 	// test remove role from instance profile failure
-	s = S3Repository{NamePrefix: "dataset", S3: newMockS3Client(t), IAM: newMockIAMClient(t)}
+	s = S3Repository{NamePrefix: "dataset", PathPrefix: "/test/", S3: newMockS3Client(t), IAM: newMockIAMClient(t)}
 	s.IAM.(*mockIAMClient).err["RemoveRoleFromInstanceProfileWithContext"] = awserr.New("InternalError", "Internal Error", nil)
 
 	err = s.RevokeAccess(context.TODO(), id)
@@ -371,7 +378,7 @@ func TestRevokeAccess(t *testing.T) {
 	}
 
 	// test delete instance profile failure
-	s = S3Repository{NamePrefix: "dataset", S3: newMockS3Client(t), IAM: newMockIAMClient(t)}
+	s = S3Repository{NamePrefix: "dataset", PathPrefix: "/test/", S3: newMockS3Client(t), IAM: newMockIAMClient(t)}
 	s.IAM.(*mockIAMClient).err["DeleteInstanceProfileWithContext"] = awserr.New("InternalError", "Internal Error", nil)
 
 	err = s.RevokeAccess(context.TODO(), id)
@@ -391,7 +398,7 @@ func TestRevokeAccess(t *testing.T) {
 	}
 
 	// test delete role failure
-	s = S3Repository{NamePrefix: "dataset", S3: newMockS3Client(t), IAM: newMockIAMClient(t)}
+	s = S3Repository{NamePrefix: "dataset", PathPrefix: "/test/", S3: newMockS3Client(t), IAM: newMockIAMClient(t)}
 	s.IAM.(*mockIAMClient).err["DeleteRoleWithContext"] = awserr.New("InternalError", "Internal Error", nil)
 
 	err = s.RevokeAccess(context.TODO(), id)

--- a/s3datarepository/iam_test.go
+++ b/s3datarepository/iam_test.go
@@ -145,7 +145,7 @@ func TestGrantAccess(t *testing.T) {
 	var expectedCode, expectedMessage, id string
 
 	// test success, derivative false
-	s := S3Repository{NamePrefix: "dataset", PathPrefix: "/test/", S3: newMockS3Client(t), IAM: newMockIAMClient(t)}
+	s := S3Repository{NamePrefix: "dataset", IAMPathPrefix: "/test/", S3: newMockS3Client(t), IAM: newMockIAMClient(t)}
 	id = "78DAFEF1-E4D3-48E5-A45C-6E3CA0161F08"
 	expected := &dataset.Access{
 		"policy_arn":            fmt.Sprintf("arn:aws:iam::12345678910:policy/test/dataset-%s-OriginalPlc", id),
@@ -165,7 +165,7 @@ func TestGrantAccess(t *testing.T) {
 	}
 
 	// test success, derivative true
-	s = S3Repository{NamePrefix: "dataset", PathPrefix: "/test/", S3: newMockS3Client(t), IAM: newMockIAMClient(t)}
+	s = S3Repository{NamePrefix: "dataset", IAMPathPrefix: "/test/", S3: newMockS3Client(t), IAM: newMockIAMClient(t)}
 	id = "78DAFEF1-E4D3-48E5-A45C-6E3CA0161F08"
 	expected = &dataset.Access{
 		"policy_arn":            fmt.Sprintf("arn:aws:iam::12345678910:policy/test/dataset-%s-DerivativePlc", id),
@@ -185,7 +185,7 @@ func TestGrantAccess(t *testing.T) {
 	}
 
 	// test empty id
-	s = S3Repository{NamePrefix: "dataset", PathPrefix: "/test/", S3: newMockS3Client(t), IAM: newMockIAMClient(t)}
+	s = S3Repository{NamePrefix: "dataset", IAMPathPrefix: "/test/", S3: newMockS3Client(t), IAM: newMockIAMClient(t)}
 	_, err = s.GrantAccess(context.TODO(), "", false)
 	if aerr, ok := err.(apierror.Error); ok {
 		if aerr.Code != apierror.ErrBadRequest {
@@ -196,7 +196,7 @@ func TestGrantAccess(t *testing.T) {
 	}
 
 	// test create policy failure
-	s = S3Repository{NamePrefix: "dataset", PathPrefix: "/test/", S3: newMockS3Client(t), IAM: newMockIAMClient(t)}
+	s = S3Repository{NamePrefix: "dataset", IAMPathPrefix: "/test/", S3: newMockS3Client(t), IAM: newMockIAMClient(t)}
 	id = "78DAFEF1-E4D3-48E5-A45C-6E3CA0161F08"
 	expectedCode = apierror.ErrServiceUnavailable
 	expectedMessage = fmt.Sprintf("failed to create IAM policy")
@@ -219,7 +219,7 @@ func TestGrantAccess(t *testing.T) {
 	}
 
 	// test create role failure
-	s = S3Repository{NamePrefix: "dataset", PathPrefix: "/test/", S3: newMockS3Client(t), IAM: newMockIAMClient(t)}
+	s = S3Repository{NamePrefix: "dataset", IAMPathPrefix: "/test/", S3: newMockS3Client(t), IAM: newMockIAMClient(t)}
 	id = "78DAFEF1-E4D3-48E5-A45C-6E3CA0161F08"
 	expectedCode = apierror.ErrServiceUnavailable
 	expectedMessage = fmt.Sprintf("failed to create IAM role roleDataset_%s", id)
@@ -242,7 +242,7 @@ func TestGrantAccess(t *testing.T) {
 	}
 
 	// test attach role policy failure
-	s = S3Repository{NamePrefix: "dataset", PathPrefix: "/test/", S3: newMockS3Client(t), IAM: newMockIAMClient(t)}
+	s = S3Repository{NamePrefix: "dataset", IAMPathPrefix: "/test/", S3: newMockS3Client(t), IAM: newMockIAMClient(t)}
 	id = "78DAFEF1-E4D3-48E5-A45C-6E3CA0161F08"
 	expectedCode = apierror.ErrServiceUnavailable
 	expectedMessage = fmt.Sprintf("failed to attach policy to role roleDataset_%s", id)
@@ -265,7 +265,7 @@ func TestGrantAccess(t *testing.T) {
 	}
 
 	// test create instance profile failure
-	s = S3Repository{NamePrefix: "dataset", PathPrefix: "/test/", S3: newMockS3Client(t), IAM: newMockIAMClient(t)}
+	s = S3Repository{NamePrefix: "dataset", IAMPathPrefix: "/test/", S3: newMockS3Client(t), IAM: newMockIAMClient(t)}
 	id = "78DAFEF1-E4D3-48E5-A45C-6E3CA0161F08"
 	expectedCode = apierror.ErrServiceUnavailable
 	expectedMessage = fmt.Sprintf("failed to create instance profile roleDataset_%s", id)
@@ -288,7 +288,7 @@ func TestGrantAccess(t *testing.T) {
 	}
 
 	// test add role to instance profile failure
-	s = S3Repository{NamePrefix: "dataset", PathPrefix: "/test/", S3: newMockS3Client(t), IAM: newMockIAMClient(t)}
+	s = S3Repository{NamePrefix: "dataset", IAMPathPrefix: "/test/", S3: newMockS3Client(t), IAM: newMockIAMClient(t)}
 	id = "78DAFEF1-E4D3-48E5-A45C-6E3CA0161F08"
 	expectedCode = apierror.ErrServiceUnavailable
 	expectedMessage = fmt.Sprintf("failed to add role to instance profile roleDataset_%s", id)
@@ -316,7 +316,7 @@ func TestRevokeAccess(t *testing.T) {
 	var expectedCode, expectedMessage, id string
 
 	// test success
-	s := S3Repository{NamePrefix: "dataset", PathPrefix: "/test/", S3: newMockS3Client(t), IAM: newMockIAMClient(t)}
+	s := S3Repository{NamePrefix: "dataset", IAMPathPrefix: "/test/", S3: newMockS3Client(t), IAM: newMockIAMClient(t)}
 	id = "78DAFEF1-E4D3-48E5-A45C-6E3CA0161F08"
 	err := s.RevokeAccess(context.TODO(), id)
 	if err != nil {
@@ -324,7 +324,7 @@ func TestRevokeAccess(t *testing.T) {
 	}
 
 	// test empty id
-	s = S3Repository{NamePrefix: "dataset", PathPrefix: "/test/", S3: newMockS3Client(t), IAM: newMockIAMClient(t)}
+	s = S3Repository{NamePrefix: "dataset", IAMPathPrefix: "/test/", S3: newMockS3Client(t), IAM: newMockIAMClient(t)}
 	err = s.RevokeAccess(context.TODO(), "")
 	if aerr, ok := err.(apierror.Error); ok {
 		if aerr.Code != apierror.ErrBadRequest {
@@ -338,7 +338,7 @@ func TestRevokeAccess(t *testing.T) {
 	expectedMessage = fmt.Sprintf("one or more errors trying to revoke access for data repository dataset-%s", id)
 
 	// test list role policies failure
-	s = S3Repository{NamePrefix: "dataset", PathPrefix: "/test/", S3: newMockS3Client(t), IAM: newMockIAMClient(t)}
+	s = S3Repository{NamePrefix: "dataset", IAMPathPrefix: "/test/", S3: newMockS3Client(t), IAM: newMockIAMClient(t)}
 	s.IAM.(*mockIAMClient).err["ListAttachedRolePoliciesWithContext"] = awserr.New("InternalError", "Internal Error", nil)
 
 	err = s.RevokeAccess(context.TODO(), id)
@@ -358,7 +358,7 @@ func TestRevokeAccess(t *testing.T) {
 	}
 
 	// test remove role from instance profile failure
-	s = S3Repository{NamePrefix: "dataset", PathPrefix: "/test/", S3: newMockS3Client(t), IAM: newMockIAMClient(t)}
+	s = S3Repository{NamePrefix: "dataset", IAMPathPrefix: "/test/", S3: newMockS3Client(t), IAM: newMockIAMClient(t)}
 	s.IAM.(*mockIAMClient).err["RemoveRoleFromInstanceProfileWithContext"] = awserr.New("InternalError", "Internal Error", nil)
 
 	err = s.RevokeAccess(context.TODO(), id)
@@ -378,7 +378,7 @@ func TestRevokeAccess(t *testing.T) {
 	}
 
 	// test delete instance profile failure
-	s = S3Repository{NamePrefix: "dataset", PathPrefix: "/test/", S3: newMockS3Client(t), IAM: newMockIAMClient(t)}
+	s = S3Repository{NamePrefix: "dataset", IAMPathPrefix: "/test/", S3: newMockS3Client(t), IAM: newMockIAMClient(t)}
 	s.IAM.(*mockIAMClient).err["DeleteInstanceProfileWithContext"] = awserr.New("InternalError", "Internal Error", nil)
 
 	err = s.RevokeAccess(context.TODO(), id)
@@ -398,7 +398,7 @@ func TestRevokeAccess(t *testing.T) {
 	}
 
 	// test delete role failure
-	s = S3Repository{NamePrefix: "dataset", PathPrefix: "/test/", S3: newMockS3Client(t), IAM: newMockIAMClient(t)}
+	s = S3Repository{NamePrefix: "dataset", IAMPathPrefix: "/test/", S3: newMockS3Client(t), IAM: newMockIAMClient(t)}
 	s.IAM.(*mockIAMClient).err["DeleteRoleWithContext"] = awserr.New("InternalError", "Internal Error", nil)
 
 	err = s.RevokeAccess(context.TODO(), id)

--- a/s3datarepository/s3datarepository.go
+++ b/s3datarepository/s3datarepository.go
@@ -25,11 +25,11 @@ type S3RepositoryOption func(*S3Repository)
 
 // S3Repository is an implementation of a data respository in S3
 type S3Repository struct {
-	NamePrefix string
-	PathPrefix string
-	IAM        iamiface.IAMAPI
-	S3         s3iface.S3API
-	config     *aws.Config
+	NamePrefix    string
+	IAMPathPrefix string
+	IAM           iamiface.IAMAPI
+	S3            s3iface.S3API
+	config        *aws.Config
 }
 
 // NewDefaultRepository creates a new repository from the default config data
@@ -67,8 +67,8 @@ func NewDefaultRepository(config map[string]interface{}) (*S3Repository, error) 
 		opts = append(opts, WithEndpoint(endpoint))
 	}
 
-	// set default PathPrefix
-	opts = append(opts, WithPathPrefix("/dataset/"))
+	// set default IAMPathPrefix
+	opts = append(opts, WithIAMPathPrefix("/spinup/dataset/"))
 
 	return New(opts...)
 }
@@ -115,11 +115,11 @@ func WithEndpoint(endpoint string) S3RepositoryOption {
 	}
 }
 
-// WithPathPrefix sets the PathPrefix for the S3Repository
-// This is used as the IAM Path prefix for IAM resources
-func WithPathPrefix(prefix string) S3RepositoryOption {
+// WithIAMPathPrefix sets the IAMPathPrefix for the S3Repository
+// This is used as the Path prefix for IAM resources
+func WithIAMPathPrefix(prefix string) S3RepositoryOption {
 	return func(s *S3Repository) {
-		s.PathPrefix = prefix
+		s.IAMPathPrefix = prefix
 	}
 }
 

--- a/s3datarepository/s3datarepository.go
+++ b/s3datarepository/s3datarepository.go
@@ -26,6 +26,7 @@ type S3RepositoryOption func(*S3Repository)
 // S3Repository is an implementation of a data respository in S3
 type S3Repository struct {
 	NamePrefix string
+	PathPrefix string
 	IAM        iamiface.IAMAPI
 	S3         s3iface.S3API
 	config     *aws.Config
@@ -65,6 +66,9 @@ func NewDefaultRepository(config map[string]interface{}) (*S3Repository, error) 
 	if endpoint != "" {
 		opts = append(opts, WithEndpoint(endpoint))
 	}
+
+	// set default PathPrefix
+	opts = append(opts, WithPathPrefix("/dataset/"))
 
 	return New(opts...)
 }
@@ -108,6 +112,14 @@ func WithEndpoint(endpoint string) S3RepositoryOption {
 	return func(s *S3Repository) {
 		log.Debugf("setting endpoint %s", endpoint)
 		s.config.WithEndpoint(endpoint)
+	}
+}
+
+// WithPathPrefix sets the PathPrefix for the S3Repository
+// This is used as the IAM Path prefix for IAM resources
+func WithPathPrefix(prefix string) S3RepositoryOption {
+	return func(s *S3Repository) {
+		s.PathPrefix = prefix
 	}
 }
 

--- a/s3datarepository/s3datarepository_test.go
+++ b/s3datarepository/s3datarepository_test.go
@@ -102,6 +102,8 @@ func TestNewDefaultRepository(t *testing.T) {
 		"endpoint": "https://under.mydesk.amazonaws.com",
 	}
 
+	expectedPathPrefix := "/dataset/"
+
 	s, err := NewDefaultRepository(testConfig)
 	if err != nil {
 		t.Errorf("expected nil error, got: %s", err)
@@ -121,6 +123,10 @@ func TestNewDefaultRepository(t *testing.T) {
 
 	if s.config.Endpoint == nil {
 		t.Error("expected config Endpoint to be set, got nil")
+	}
+
+	if s.PathPrefix != expectedPathPrefix {
+		t.Errorf("expected PathPrefix to be '%s', got '%s'", expectedPathPrefix, s.PathPrefix)
 	}
 }
 

--- a/s3datarepository/s3datarepository_test.go
+++ b/s3datarepository/s3datarepository_test.go
@@ -102,7 +102,7 @@ func TestNewDefaultRepository(t *testing.T) {
 		"endpoint": "https://under.mydesk.amazonaws.com",
 	}
 
-	expectedPathPrefix := "/dataset/"
+	expectedIAMPathPrefix := "/spinup/dataset/"
 
 	s, err := NewDefaultRepository(testConfig)
 	if err != nil {
@@ -125,8 +125,8 @@ func TestNewDefaultRepository(t *testing.T) {
 		t.Error("expected config Endpoint to be set, got nil")
 	}
 
-	if s.PathPrefix != expectedPathPrefix {
-		t.Errorf("expected PathPrefix to be '%s', got '%s'", expectedPathPrefix, s.PathPrefix)
+	if s.IAMPathPrefix != expectedIAMPathPrefix {
+		t.Errorf("expected IAMPathPrefix to be '%s', got '%s'", expectedIAMPathPrefix, s.IAMPathPrefix)
 	}
 }
 


### PR DESCRIPTION
This adds a default PathPrefix for the s3datarepository, so we can better separate all IAM resources that get created and more easily scope required IAM privileges.
Also fixes a bug with GrantAccess rollback.