### PR TITLE
Initial support for deleting datasets

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ GET /v1/ds/metrics
 
 POST /v1/ds/{account}/datasets
 GET /v1/ds/{account}/datasets/{id}
+DELETE /v1/ds/{account}/datasets/{id}
 ```
 
 ## Usage
@@ -163,6 +164,17 @@ GET /v1/ds/{account}/datasets/{id}
 | **404 Not Found**             | dataset not found                    |
 | **500 Internal Server Error** | a server error occurred              |
 
+### Delete a dataset
+
+DELETE /v1/ds/{account}/datasets/{id}
+
+| Response Code                 | Definition                           |
+| ----------------------------- | -------------------------------------|
+| **204 OK**                    | okay                                 |
+| **400 Bad Request**           | badly formed request                 |
+| **404 Not Found**             | dataset not found                    |
+| **500 Internal Server Error** | a server error occurred              |
+
 
 ## Authentication
 
@@ -180,7 +192,10 @@ You can specify a single `metadataRepository` where metadata about all the diffe
         {
             "Effect": "Allow",
             "Action": "s3:*",
-            "Resource": "arn:aws:s3:::spinup-example-metadata-repository/*"
+            "Resource": [
+                "arn:aws:s3:::spinup-example-metadata-repository",
+                "arn:aws:s3:::spinup-example-metadata-repository/*"
+            ]
         }
     ]
 }

--- a/api/handlers_datasets.go
+++ b/api/handlers_datasets.go
@@ -23,8 +23,8 @@ func (s *server) DatasetCreateHandler(w http.ResponseWriter, r *http.Request) {
 
 	service, ok := s.datasetServices[account]
 	if !ok {
-		log.Errorf("account not found: %s", account)
-		w.WriteHeader(http.StatusNotFound)
+		msg := fmt.Sprintf("account not found: %s", account)
+		handleError(w, apierror.New(apierror.ErrNotFound, msg, nil))
 		return
 	}
 
@@ -198,8 +198,8 @@ func (s *server) DatasetShowHandler(w http.ResponseWriter, r *http.Request) {
 
 	service, ok := s.datasetServices[account]
 	if !ok {
-		log.Errorf("account not found: %s", account)
-		w.WriteHeader(http.StatusNotFound)
+		msg := fmt.Sprintf("account not found: %s", account)
+		handleError(w, apierror.New(apierror.ErrNotFound, msg, nil))
 		return
 	}
 
@@ -276,8 +276,8 @@ func (s *server) DatasetDeleteHandler(w http.ResponseWriter, r *http.Request) {
 
 	service, ok := s.datasetServices[account]
 	if !ok {
-		log.Errorf("account not found: %s", account)
-		w.WriteHeader(http.StatusNotFound)
+		msg := fmt.Sprintf("account not found: %s", account)
+		handleError(w, apierror.New(apierror.ErrNotFound, msg, nil))
 		return
 	}
 

--- a/dataset/metadata.go
+++ b/dataset/metadata.go
@@ -42,99 +42,99 @@ func (m *Metadata) UnmarshalJSON(j []byte) error {
 	log.Debug("unmarshaled metadata into rawstrings")
 
 	if id, ok := rawStrings["id"]; ok {
-		if s, ok := id.(string); !ok {
+		s, ok := id.(string)
+		if !ok {
 			msg := fmt.Sprintf("id is not a string: %+v", rawStrings["id"])
 			return errors.New(msg)
-		} else {
-			m.ID = s
 		}
+		m.ID = s
 	}
 
 	if name, ok := rawStrings["name"]; ok {
-		if s, ok := name.(string); !ok {
+		s, ok := name.(string)
+		if !ok {
 			msg := fmt.Sprintf("name is not a string: %+v", rawStrings["name"])
 			return errors.New(msg)
-		} else {
-			m.Name = s
 		}
+		m.Name = s
 	}
 
 	if desc, ok := rawStrings["description"]; ok {
-		if s, ok := desc.(string); !ok {
+		s, ok := desc.(string)
+		if !ok {
 			msg := fmt.Sprintf("description is not a string: %+v", rawStrings["description"])
 			return errors.New(msg)
-		} else {
-			m.Description = s
 		}
+		m.Description = s
 	}
 
 	if createdAt, ok := rawStrings["created_at"]; ok {
-		if ca, ok := createdAt.(string); !ok {
+		ca, ok := createdAt.(string)
+		if !ok {
 			msg := fmt.Sprintf("created_at is not a string: %+v", rawStrings["created_at"])
 			return errors.New(msg)
-		} else {
-			if ca != "" {
-				t, err := time.Parse(time.RFC3339, ca)
-				if err != nil {
-					msg := fmt.Sprintf("failed to parse created at as time: %+v", t)
-					return errors.New(msg)
-				}
-				m.CreatedAt = &t
+		}
+		if ca != "" {
+			t, err := time.Parse(time.RFC3339, ca)
+			if err != nil {
+				msg := fmt.Sprintf("failed to parse created at as time: %+v", t)
+				return errors.New(msg)
 			}
+			m.CreatedAt = &t
 		}
 	}
 
 	if createdBy, ok := rawStrings["created_by"]; ok {
-		if s, ok := createdBy.(string); !ok {
+		s, ok := createdBy.(string)
+		if !ok {
 			msg := fmt.Sprintf("created_by is not a string: %+v", rawStrings["created_by"])
 			return errors.New(msg)
-		} else {
-			m.CreatedBy = s
 		}
+		m.CreatedBy = s
 	}
 
 	if dataClassifications, ok := rawStrings["data_classifications"]; ok {
-		if dcs, ok := dataClassifications.([]interface{}); !ok {
+		dcs, ok := dataClassifications.([]interface{})
+		if !ok {
 			msg := fmt.Sprintf("data_classification at is not a []interface{}: %+v", rawStrings["data_classifications"])
 			return errors.New(msg)
-		} else {
-			m.DataClassifications = []string{}
-			for _, iface := range dcs {
-				if dc, ok := iface.(string); !ok {
-					msg := fmt.Sprintf("data classification value is not a string: %+v", iface)
-					return errors.New(msg)
-				} else {
-					m.DataClassifications = append(m.DataClassifications, dc)
-				}
+		}
+		m.DataClassifications = []string{}
+		for _, iface := range dcs {
+			dc, ok := iface.(string)
+			if !ok {
+				msg := fmt.Sprintf("data classification value is not a string: %+v", iface)
+				return errors.New(msg)
 			}
+			m.DataClassifications = append(m.DataClassifications, dc)
 		}
 	}
 
 	if dataFormat, ok := rawStrings["data_format"]; ok {
-		if s, ok := dataFormat.(string); !ok {
+		s, ok := dataFormat.(string)
+		if !ok {
 			msg := fmt.Sprintf("data_format is not a string: %+v", rawStrings["data_format"])
 			return errors.New(msg)
-		} else {
-			m.DataFormat = s
 		}
+		m.DataFormat = s
 	}
 
 	if dataStorage, ok := rawStrings["data_storage"]; ok {
-		if s, ok := dataStorage.(string); !ok {
+		s, ok := dataStorage.(string)
+		if !ok {
 			msg := fmt.Sprintf("data_storage is not a string: %+v", rawStrings["data_storage"])
 			return errors.New(msg)
-		} else {
-			m.DataStorage = s
 		}
+		m.DataStorage = s
 	}
 
 	if derivative, ok := rawStrings["derivative"]; ok {
-		if b, ok := derivative.(bool); !ok {
+		b, ok := derivative.(bool)
+		if !ok {
 			msg := fmt.Sprintf("derivative is not a boolean: %+v", rawStrings["derivative"])
 			return errors.New(msg)
-		} else {
-			m.Derivative = b
 		}
+		m.Derivative = b
 	}
 
 	if duaUrl, ok := rawStrings["dua_url"]; ok {
@@ -142,39 +142,38 @@ func (m *Metadata) UnmarshalJSON(j []byte) error {
 		if !ok {
 			msg := fmt.Sprintf("dua url is not a string: %+v", rawStrings["dua_url"])
 			return errors.New(msg)
-		} else {
-			u, err := url.Parse(d)
-			if err != nil {
-				msg := fmt.Sprintf("failed to parse dua url at as url: %+v", rawStrings["dua_url"])
-				return errors.New(msg)
-			}
-			m.DuaURL = u
 		}
+		u, err := url.Parse(d)
+		if err != nil {
+			msg := fmt.Sprintf("failed to parse dua url at as url: %+v", rawStrings["dua_url"])
+			return errors.New(msg)
+		}
+		m.DuaURL = u
 	}
 
 	if modifiedAt, ok := rawStrings["modified_at"]; ok {
-		if ma, ok := modifiedAt.(string); !ok {
+		ma, ok := modifiedAt.(string)
+		if !ok {
 			msg := fmt.Sprintf("modified_at is not a string: %+v", rawStrings["modified_at"])
 			return errors.New(msg)
-		} else {
-			if ma != "" {
-				t, err := time.Parse(time.RFC3339, ma)
-				if err != nil {
-					msg := fmt.Sprintf("failed to parse modified_at as time: %+v", t)
-					return errors.New(msg)
-				}
-				m.ModifiedAt = &t
+		}
+		if ma != "" {
+			t, err := time.Parse(time.RFC3339, ma)
+			if err != nil {
+				msg := fmt.Sprintf("failed to parse modified_at as time: %+v", t)
+				return errors.New(msg)
 			}
+			m.ModifiedAt = &t
 		}
 	}
 
 	if modifiedBy, ok := rawStrings["modified_by"]; ok {
-		if s, ok := modifiedBy.(string); !ok {
+		s, ok := modifiedBy.(string)
+		if !ok {
 			msg := fmt.Sprintf("modified_by is not a string: %+v", rawStrings["modified_by"])
 			return errors.New(msg)
-		} else {
-			m.ModifiedBy = s
 		}
+		m.ModifiedBy = s
 	}
 
 	if proctorResponseURL, ok := rawStrings["proctor_response_url"]; ok {
@@ -182,33 +181,32 @@ func (m *Metadata) UnmarshalJSON(j []byte) error {
 		if !ok {
 			msg := fmt.Sprintf("proctor_response_url is not a string: %+v", rawStrings["proctor_response_url"])
 			return errors.New(msg)
-		} else {
-			u, err := url.Parse(p)
-			if err != nil {
-				msg := fmt.Sprintf("failed to parse proctor_response_url at as url: %+v", rawStrings["proctor_response_url"])
-				return errors.New(msg)
-			}
-			m.ProctorResponseURL = u
 		}
+		u, err := url.Parse(p)
+		if err != nil {
+			msg := fmt.Sprintf("failed to parse proctor_response_url at as url: %+v", rawStrings["proctor_response_url"])
+			return errors.New(msg)
+		}
+		m.ProctorResponseURL = u
 	}
 
 	if sourceIds, ok := rawStrings["source_ids"]; ok {
 		if sourceIds == nil {
 			m.SourceIDs = []string{}
 		} else {
-			if sids, ok := sourceIds.([]interface{}); !ok {
+			sids, ok := sourceIds.([]interface{})
+			if !ok {
 				msg := fmt.Sprintf("source_ids at is not a []interface{}: %+v", rawStrings["source_ids"])
 				return errors.New(msg)
-			} else {
-				m.SourceIDs = []string{}
-				for _, iface := range sids {
-					if sid, ok := iface.(string); !ok {
-						msg := fmt.Sprintf("source id value is not a string: %+v", iface)
-						return errors.New(msg)
-					} else {
-						m.SourceIDs = append(m.SourceIDs, sid)
-					}
+			}
+			m.SourceIDs = []string{}
+			for _, iface := range sids {
+				sid, ok := iface.(string)
+				if !ok {
+					msg := fmt.Sprintf("source id value is not a string: %+v", iface)
+					return errors.New(msg)
 				}
+				m.SourceIDs = append(m.SourceIDs, sid)
 			}
 		}
 	}

--- a/dataset/metadata.go
+++ b/dataset/metadata.go
@@ -193,17 +193,21 @@ func (m *Metadata) UnmarshalJSON(j []byte) error {
 	}
 
 	if sourceIds, ok := rawStrings["source_ids"]; ok {
-		if sids, ok := sourceIds.([]interface{}); !ok {
-			msg := fmt.Sprintf("source_ids at is not a []interface{}: %+v", rawStrings["source_ids"])
-			return errors.New(msg)
-		} else {
+		if sourceIds == nil {
 			m.SourceIDs = []string{}
-			for _, iface := range sids {
-				if sid, ok := iface.(string); !ok {
-					msg := fmt.Sprintf("source id value is not a string: %+v", iface)
-					return errors.New(msg)
-				} else {
-					m.SourceIDs = append(m.SourceIDs, sid)
+		} else {
+			if sids, ok := sourceIds.([]interface{}); !ok {
+				msg := fmt.Sprintf("source_ids at is not a []interface{}: %+v", rawStrings["source_ids"])
+				return errors.New(msg)
+			} else {
+				m.SourceIDs = []string{}
+				for _, iface := range sids {
+					if sid, ok := iface.(string); !ok {
+						msg := fmt.Sprintf("source id value is not a string: %+v", iface)
+						return errors.New(msg)
+					} else {
+						m.SourceIDs = append(m.SourceIDs, sid)
+					}
 				}
 			}
 		}

--- a/s3metadatarepository/s3metadatarepository.go
+++ b/s3metadatarepository/s3metadatarepository.go
@@ -187,7 +187,7 @@ func (s *S3Repository) Create(ctx context.Context, account, id string, metadata 
 		Key:         aws.String(key),
 	})
 	if err != nil {
-		return nil, ErrCode("failed to put s3 metadata object "+key, err)
+		return nil, ErrCode("failed to put s3 metadata object: "+key, err)
 	}
 
 	log.Debugf("output from s3 metadata object put: %+v", out)
@@ -218,7 +218,7 @@ func (s *S3Repository) Get(ctx context.Context, account, id string) (*dataset.Me
 		Key:    aws.String(key),
 	})
 	if err != nil {
-		return nil, ErrCode("failed to get metadata object from s3 "+key, err)
+		return nil, ErrCode("failed to get metadata object from s3: "+key, err)
 	}
 	defer out.Body.Close()
 
@@ -259,6 +259,20 @@ func (s *S3Repository) Delete(ctx context.Context, account, id string) error {
 	}
 
 	log.Debugf("deleting s3metadatarepository object in account '%s' with id: %s", account, id)
+
+	key := s.Prefix + "/" + account
+	if !strings.HasSuffix(account, "/") && !strings.HasPrefix(id, "/") {
+		key = key + "/"
+	}
+	key = key + id
+
+	_, err := s.S3.DeleteObjectWithContext(ctx, &s3.DeleteObjectInput{
+		Bucket: aws.String(s.Bucket),
+		Key:    aws.String(key),
+	})
+	if err != nil {
+		return ErrCode("failed to delete s3 metadata object: "+key, err)
+	}
 
 	return nil
 }


### PR DESCRIPTION
This PR adds a DELETE endpoint which currently deletes the metadata object for the giver dataset, cleans up IAM policies associated with the S3 repository, and deletes the S3 bucket, if empty.