### PR TITLE
Only create an access policy when provisioning datasets

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,14 +74,6 @@ POST /v1/ds/{account}/datasets
             "e15d2282-9c68-46b5-801c-2b5a62484624",
             "a7c082ee-f711-48fa-8a57-25c95b3a6ddd"
         ]
-    },
-    "access": {
-        "instance_profile_arn": "arn:aws:iam::516855177326:instance-profile/roleDataset_d37b375b-d136-4b17-8666-5036dc554a66",
-        "instance_profile_name": "roleDataset_d37b375b-d136-4b17-8666-5036dc554a66",
-        "policy_arn": "arn:aws:iam::516855177326:policy/dataset-localdev-d37b375b-d136-4b17-8666-5036dc554a66-DerivativePlc",
-        "policy_name": "dataset-localdev-d37b375b-d136-4b17-8666-5036dc554a66-DerivativePlc",
-        "role_arn": "arn:aws:iam::516855177326:role/roleDataset_d37b375b-d136-4b17-8666-5036dc554a66",
-        "role_name": "roleDataset_d37b375b-d136-4b17-8666-5036dc554a66"
     }
 }
 ```

--- a/dataset/dataset.go
+++ b/dataset/dataset.go
@@ -22,7 +22,7 @@ type MetadataRepository interface {
 
 // DataRepository is an interface for data repository
 type DataRepository interface {
-	Provision(ctx context.Context, id string, tags []*Tag) (string, error)
+	Provision(ctx context.Context, id string, derivative bool, tags []*Tag) (string, error)
 	Deprovision(ctx context.Context, id string) error
 	Delete(ctx context.Context, id string) error
 	Describe(ctx context.Context, id string) (*Repository, error)

--- a/s3datarepository/iam.go
+++ b/s3datarepository/iam.go
@@ -10,6 +10,7 @@ import (
 	"github.com/YaleSpinup/ds-api/dataset"
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/iam"
+	"github.com/aws/aws-sdk-go/service/sts"
 	log "github.com/sirupsen/logrus"
 )
 
@@ -25,6 +26,107 @@ type PolicyStatement struct {
 type PolicyDoc struct {
 	Version   string
 	Statement []PolicyStatement
+}
+
+// createPolicy creates the appropriate access policy for the data repository, depending if it's a derivative or not
+func (s *S3Repository) createPolicy(ctx context.Context, id string, derivative bool) error {
+	if id == "" {
+		return apierror.New(apierror.ErrBadRequest, "invalid input", errors.New("empty id"))
+	}
+
+	name := id
+	if s.NamePrefix != "" {
+		name = s.NamePrefix + "-" + name
+	}
+
+	policyName := fmt.Sprintf("policy-%s", name)
+
+	var policyDoc []byte
+	var err error
+
+	log.Debugf("generating access policy for bucket '%s'", name)
+
+	if derivative {
+		policyDoc, err = s.derivativeAccessPolicy(name)
+	} else {
+		policyDoc, err = s.originalAccessPolicy(name)
+	}
+	if err != nil {
+		return ErrCode("failed to generate IAM policy for bucket "+name, err)
+	}
+
+	log.Debugf("creating access policy for bucket '%s'", name)
+
+	// create policy
+	policyOutput, err := s.IAM.CreatePolicyWithContext(ctx, &iam.CreatePolicyInput{
+		Description:    aws.String(fmt.Sprintf("Access policy for bucket %s", name)),
+		Path:           aws.String(s.IAMPathPrefix),
+		PolicyDocument: aws.String(string(policyDoc)),
+		PolicyName:     aws.String(policyName),
+	})
+	if err != nil {
+		return ErrCode("failed to create IAM policy", err)
+	}
+
+	log.Debugf("created policy: %s", *policyOutput.Policy.Arn)
+
+	return nil
+}
+
+// deletePolicy deletes the access policy for the given data repository
+func (s *S3Repository) deletePolicy(ctx context.Context, id string) error {
+	if id == "" {
+		return apierror.New(apierror.ErrBadRequest, "invalid input", errors.New("empty id"))
+	}
+
+	name := id
+	if s.NamePrefix != "" {
+		name = s.NamePrefix + "-" + name
+	}
+
+	policyName := fmt.Sprintf("policy-%s", name)
+
+	policyArn, err := s.getPolicyArn(ctx, policyName)
+	if err != nil {
+		return ErrCode("failed to get ARN for policy "+policyName, err)
+	}
+
+	// TODO: check if policy is used anywhere before deleting
+
+	if _, err = s.IAM.DeletePolicyWithContext(ctx, &iam.DeletePolicyInput{PolicyArn: aws.String(policyArn)}); err != nil {
+		return ErrCode("failed to delete policy "+policyArn, err)
+	}
+
+	log.Debugf("deleted policy: %s", policyArn)
+
+	return nil
+}
+
+// getPolicyArn constructs the policy ARN from the policy name
+func (s *S3Repository) getPolicyArn(ctx context.Context, name string) (string, error) {
+	if name == "" {
+		return "", apierror.New(apierror.ErrBadRequest, "invalid input", errors.New("empty name"))
+	}
+
+	// prepend the path prefix
+	if s.IAMPathPrefix == "" {
+		name = "/" + name
+	} else {
+		name = s.IAMPathPrefix + name
+	}
+
+	log.Debugf("constructing ARN for policy %s", name)
+
+	callerID, err := s.STS.GetCallerIdentityWithContext(ctx, &sts.GetCallerIdentityInput{})
+	if err != nil {
+		return "", err
+	}
+
+	policyArn := fmt.Sprintf("arn:aws:iam::%s:policy%s", *callerID.Account, name)
+
+	log.Debugf("policy ARN: %s", policyArn)
+
+	return policyArn, nil
 }
 
 // GrantAccess sets up the appropriate access to the data repository, depending if it's a derivative or not,

--- a/s3datarepository/iam.go
+++ b/s3datarepository/iam.go
@@ -59,7 +59,7 @@ func (s *S3Repository) createPolicy(ctx context.Context, id string, derivative b
 
 	// create policy
 	policyOutput, err := s.IAM.CreatePolicyWithContext(ctx, &iam.CreatePolicyInput{
-		Description:    aws.String(fmt.Sprintf("Access policy for bucket %s", name)),
+		Description:    aws.String(fmt.Sprintf("Access policy for dataset bucket %s", name)),
 		Path:           aws.String(s.IAMPathPrefix),
 		PolicyDocument: aws.String(string(policyDoc)),
 		PolicyName:     aws.String(policyName),

--- a/s3datarepository/iam_test.go
+++ b/s3datarepository/iam_test.go
@@ -14,6 +14,8 @@ import (
 	"github.com/aws/aws-sdk-go/aws/request"
 	"github.com/aws/aws-sdk-go/service/iam"
 	"github.com/aws/aws-sdk-go/service/iam/iamiface"
+	"github.com/aws/aws-sdk-go/service/sts"
+	"github.com/aws/aws-sdk-go/service/sts/stsiface"
 )
 
 // mockIAMClient is a fake IAM client
@@ -23,10 +25,22 @@ type mockIAMClient struct {
 	err map[string]error
 }
 
+// mockSTSClient is a fake STS client
+type mockSTSClient struct {
+	stsiface.STSAPI
+	t *testing.T
+}
+
 func newMockIAMClient(t *testing.T) iamiface.IAMAPI {
 	return &mockIAMClient{
 		t:   t,
 		err: make(map[string]error),
+	}
+}
+
+func newMockSTSClient(t *testing.T) stsiface.STSAPI {
+	return &mockSTSClient{
+		t: t,
 	}
 }
 
@@ -139,6 +153,14 @@ func (i *mockIAMClient) RemoveRoleFromInstanceProfileWithContext(ctx context.Con
 		return nil, err
 	}
 	return &iam.RemoveRoleFromInstanceProfileOutput{}, nil
+}
+
+func (i *mockSTSClient) GetCallerIdentityWithContext(ctx context.Context, input *sts.GetCallerIdentityInput, opts ...request.Option) (*sts.GetCallerIdentityOutput, error) {
+	return &sts.GetCallerIdentityOutput{
+		Account: aws.String("123456789012"),
+		Arn:     aws.String("arn:aws:iam::123456789012:user/test"),
+		UserId:  aws.String("test"),
+	}, nil
 }
 
 func TestGrantAccess(t *testing.T) {


### PR DESCRIPTION
This PR starts to change how we handle access to dataset repositories. Instead of generating a role/instanceProfile, now we just generate an IAM policy during the `Provision`. This policy is strictly associated with the dataset and its name/ARN can be determined programatically. The policy gets deleted during a `Delete` of a dataset (currently only if it's not used anywhere, but eventually will get automatically detached).
The plan is to attach this policy to any roles that need to access a specific dataset.
The `GrantAccess` and `RevokeAccess` funcs are thus not currently being used but I left them in place as they'll get reworked when I start working on the actual access provisioning/de-provisioning for servers.