### PR TITLE
create, delete, list dataset users. reset keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,11 @@ DELETE /v1/ds/{account}/datasets/{id}
 GET /v1/ds/{account}/datasets/{id}/instances
 POST /v1/ds/{account}/datasets/{id}/instances
 DELETE /v1/ds/{account}/datasets/{id}/instances/{instance_id}
+
+GET /v1/ds/{account}/datasets/{id}/users
+POST /v1/ds/{account}/datasets/{id}/users
+DELETE /v1/ds/{account}/datasets/{id}/users
+PUT /v1/ds/{account}/datasets/{id}/users
 ```
 
 ## Usage
@@ -231,6 +236,99 @@ DELETE /v1/ds/{account}/datasets/{id}/instances/{instance_id}
 | **404 Not Found**             | account/dataset not found                    |
 | **500 Internal Server Error** | a server error occurred                      |
 
+### Create a user for a dataset
+
+POST /v1/ds/{account}/datasets/{id}/users
+
+Request body is empty.
+
+#### Response
+
+```json
+{
+    "user": "dataset-ssdev-95db5a7b-466b-4aa7-bbe1-1e23ed860f32-DsTmpUsr",
+    "group": "dataset-ssdev-95db5a7b-466b-4aa7-bbe1-1e23ed860f32-DsTmpGrp",
+    "policy": "dataset-ssdev-95db5a7b-466b-4aa7-bbe1-1e23ed860f32-DsTmpPlc",
+    "credentials": {
+        "akid": "XXXXXXXXXXXXXXXXXXXX",
+        "secret": "secretsecretsecretsecretsecretsecret",
+    }
+}
+```
+
+| Response Code                 | Definition                           |
+| ----------------------------- | -------------------------------------|
+| **200 OK**                    | instance access granted              |
+| **400 Bad Request**           | badly formed request                 |
+| **404 Not Found**             | account/dataset not found            |
+| **409 Conflict**              | user already exists                  |
+| **500 Internal Server Error** | a server error occurred              |
+
+
+### Delete a user for a dataset
+
+DELETE /v1/ds/{account}/datasets/{id}/users
+
+#### Response
+
+| Response Code                 | Definition                           |
+| ----------------------------- | -------------------------------------|
+| **200 OK**                    | instance access granted              |
+| **400 Bad Request**           | badly formed request                 |
+| **404 Not Found**             | account/dataset/user not found       |
+| **500 Internal Server Error** | a server error occurred              |
+
+### Get a user for a dataset
+
+GET /v1/ds/{account}/datasets/{id}/users
+
+#### Response
+
+```json
+{
+    "dataset-ssdev-95db5a7b-466b-4aa7-bbe1-1e23ed860f32-DsTmpUsr": {
+        "keys": {
+            "XXXXXXXXXXXXXXXXXXXX": "Inactive",
+            "YYYYYYYYYYYYYYYYYYYY": "Active"
+        }
+    }
+}
+```
+
+| Response Code                 | Definition                           |
+| ----------------------------- | -------------------------------------|
+| **200 OK**                    | instance access granted              |
+| **400 Bad Request**           | badly formed request                 |
+| **404 Not Found**             | account/dataset/user not found       |
+| **500 Internal Server Error** | a server error occurred              |
+
+### Update a user's key for a dataset
+
+PUT /v1/ds/{account}/datasets/{id}/users
+
+Request body is empty.
+
+#### Response
+
+```json
+{
+    "keys": {
+        "XXXXXXXXXXXXXXXXXXXXX": "Inactive"
+    },
+    "credentials": {
+        "akid": "YYYYYYYYYYYYYYYYYYYYY",
+        "secret": "secretsecretsecretsecretsecretsecret"
+    }
+}
+```
+
+| Response Code                 | Definition                           |
+| ----------------------------- | -------------------------------------|
+| **200 OK**                    | instance access granted              |
+| **400 Bad Request**           | badly formed request                 |
+| **404 Not Found**             | account/dataset not found            |
+| **429 Limit Exceeded**        | maximum number of keys               |
+| **500 Internal Server Error** | a server error occurred              |
 
 ## Authentication
 

--- a/api/handlers_users.go
+++ b/api/handlers_users.go
@@ -1,0 +1,193 @@
+package api
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+
+	"github.com/YaleSpinup/ds-api/apierror"
+	"github.com/gorilla/mux"
+	"github.com/pkg/errors"
+	log "github.com/sirupsen/logrus"
+)
+
+// UserListHandler lists the users for a dataset
+func (s *server) UserListHandler(w http.ResponseWriter, r *http.Request) {
+	w = LogWriter{w}
+	vars := mux.Vars(r)
+	account := vars["account"]
+	id := vars["id"]
+
+	service, ok := s.datasetServices[account]
+	if !ok {
+		msg := fmt.Sprintf("account not found: %s", account)
+		handleError(w, apierror.New(apierror.ErrNotFound, msg, nil))
+		return
+	}
+
+	log.Debugf("listing users of dataset '%s' in account %s", id, account)
+	metadata, err := service.MetadataRepository.Get(r.Context(), account, id)
+	if err != nil {
+		handleError(w, err)
+		return
+	}
+
+	dataRepo, ok := service.DataRepository[metadata.DataStorage]
+	if !ok {
+		msg := fmt.Sprintf("requested data repository type not supported for this account: %s", metadata.DataStorage)
+		handleError(w, apierror.New(apierror.ErrBadRequest, msg, nil))
+		return
+	}
+
+	// list users of this data repository
+	datasetUsers, err := dataRepo.ListUsers(r.Context(), id)
+	if err != nil {
+		handleError(w, errors.Wrapf(err, "list users of data repository for dataset %s", id))
+		return
+	}
+
+	j, err := json.Marshal(datasetUsers)
+	if err != nil {
+		log.Errorf("cannot marshal reasponse(%v) into JSON: %s", datasetUsers, err)
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	w.Write(j)
+}
+
+// UserCreateHandler creates a user for a dataset
+func (s *server) UserCreateHandler(w http.ResponseWriter, r *http.Request) {
+	w = LogWriter{w}
+	vars := mux.Vars(r)
+	account := vars["account"]
+	id := vars["id"]
+
+	service, ok := s.datasetServices[account]
+	if !ok {
+		msg := fmt.Sprintf("account not found: %s", account)
+		handleError(w, apierror.New(apierror.ErrNotFound, msg, nil))
+		return
+	}
+
+	log.Debugf("creating user of dataset '%s' in account %s", id, account)
+
+	metadata, err := service.MetadataRepository.Get(r.Context(), account, id)
+	if err != nil {
+		handleError(w, err)
+		return
+	}
+
+	dataRepo, ok := service.DataRepository[metadata.DataStorage]
+	if !ok {
+		msg := fmt.Sprintf("requested data repository type not supported for this account: %s", metadata.DataStorage)
+		handleError(w, apierror.New(apierror.ErrBadRequest, msg, nil))
+		return
+	}
+
+	user, err := dataRepo.CreateUser(r.Context(), id)
+	if err != nil {
+		handleError(w, errors.Wrapf(err, "create user of data repository for dataset %s", id))
+		return
+	}
+
+	j, err := json.Marshal(user)
+	if err != nil {
+		log.Errorf("cannot marshal reasponse(%v) into JSON: %s", user, err)
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	w.Write(j)
+}
+
+// UserDeleteHandler deletes a user of a dataset
+func (s *server) UserDeleteHandler(w http.ResponseWriter, r *http.Request) {
+	w = LogWriter{w}
+	vars := mux.Vars(r)
+	account := vars["account"]
+	id := vars["id"]
+
+	service, ok := s.datasetServices[account]
+	if !ok {
+		msg := fmt.Sprintf("account not found: %s", account)
+		handleError(w, apierror.New(apierror.ErrNotFound, msg, nil))
+		return
+	}
+
+	log.Debugf("deleting user of dataset '%s' in account %s", id, account)
+
+	metadata, err := service.MetadataRepository.Get(r.Context(), account, id)
+	if err != nil {
+		handleError(w, err)
+		return
+	}
+
+	dataRepo, ok := service.DataRepository[metadata.DataStorage]
+	if !ok {
+		msg := fmt.Sprintf("requested data repository type not supported for this account: %s", metadata.DataStorage)
+		handleError(w, apierror.New(apierror.ErrBadRequest, msg, nil))
+		return
+	}
+
+	err = dataRepo.DeleteUser(r.Context(), id)
+	if err != nil {
+		handleError(w, errors.Wrapf(err, "delete user of data repository for dataset %s", id))
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	w.Write([]byte("OK"))
+}
+
+// UserUpdateHandler deletes a user of a dataset
+func (s *server) UserUpdateHandler(w http.ResponseWriter, r *http.Request) {
+	w = LogWriter{w}
+	vars := mux.Vars(r)
+	account := vars["account"]
+	id := vars["id"]
+
+	service, ok := s.datasetServices[account]
+	if !ok {
+		msg := fmt.Sprintf("account not found: %s", account)
+		handleError(w, apierror.New(apierror.ErrNotFound, msg, nil))
+		return
+	}
+
+	log.Debugf("updating user of dataset '%s' in account %s", id, account)
+
+	metadata, err := service.MetadataRepository.Get(r.Context(), account, id)
+	if err != nil {
+		handleError(w, err)
+		return
+	}
+
+	dataRepo, ok := service.DataRepository[metadata.DataStorage]
+	if !ok {
+		msg := fmt.Sprintf("requested data repository type not supported for this account: %s", metadata.DataStorage)
+		handleError(w, apierror.New(apierror.ErrBadRequest, msg, nil))
+		return
+	}
+
+	out, err := dataRepo.UpdateUser(r.Context(), id)
+	if err != nil {
+		handleError(w, errors.Wrapf(err, "update user of data repository for dataset %s", id))
+		return
+	}
+
+	j, err := json.Marshal(out)
+	if err != nil {
+		log.Errorf("cannot marshal reasponse(%v) into JSON: %s", out, err)
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	w.Write(j)
+}

--- a/api/routes.go
+++ b/api/routes.go
@@ -21,4 +21,9 @@ func (s *server) routes() {
 	api.HandleFunc("/{account}/datasets/{id}/instances", s.InstanceListHandler).Methods(http.MethodGet)
 	api.HandleFunc("/{account}/datasets/{id}/instances", s.InstanceCreateHandler).Methods(http.MethodPost)
 	api.HandleFunc("/{account}/datasets/{id}/instances/{instance_id}", s.InstanceDeleteHandler).Methods(http.MethodDelete)
+
+	api.HandleFunc("/{account}/datasets/{id}/users", s.UserListHandler).Methods(http.MethodGet)
+	api.HandleFunc("/{account}/datasets/{id}/users", s.UserCreateHandler).Methods(http.MethodPost)
+	api.HandleFunc("/{account}/datasets/{id}/users", s.UserDeleteHandler).Methods(http.MethodDelete)
+	api.HandleFunc("/{account}/datasets/{id}/users", s.UserUpdateHandler).Methods(http.MethodPut)
 }

--- a/dataset/dataset.go
+++ b/dataset/dataset.go
@@ -29,6 +29,10 @@ type DataRepository interface {
 	GrantAccess(ctx context.Context, id, instanceID string) (Access, error)
 	ListAccess(ctx context.Context, id string) (Access, error)
 	RevokeAccess(ctx context.Context, id, instanceID string) error
+	CreateUser(ctx context.Context, id string) (interface{}, error)
+	DeleteUser(ctx context.Context, id string) error
+	ListUsers(ctx context.Context, id string) (map[string]interface{}, error)
+	UpdateUser(ctx context.Context, id string) (map[string]interface{}, error)
 }
 
 // Access contains necessary information in order to access a dataset

--- a/s3datarepository/users.go
+++ b/s3datarepository/users.go
@@ -100,7 +100,7 @@ func (s *S3Repository) CreateUser(ctx context.Context, id string) (interface{}, 
 
 	log.Infof("creating user of the s3datarepository %s", name)
 
-	policyDoc, err := s.temporaryAccessPolicy(id)
+	policyDoc, err := s.temporaryAccessPolicy(name)
 	if err != nil {
 		return nil, ErrCode("generate temporary access policy for dataset "+id, err)
 	}

--- a/s3datarepository/users.go
+++ b/s3datarepository/users.go
@@ -33,9 +33,10 @@ func (s *S3Repository) ListUsers(ctx context.Context, id string) (map[string]int
 
 	output := make(map[string]interface{}, len(usersOutput))
 	for _, u := range usersOutput {
+		userName := aws.StringValue(u.UserName)
 		keyOut, err := s.IAM.ListAccessKeysWithContext(ctx, &iam.ListAccessKeysInput{UserName: u.UserName})
 		if err != nil {
-			return nil, ErrCode("failed to getting access keys for user "+aws.StringValue(u.UserName), err)
+			return nil, ErrCode("failed to getting access keys for user "+userName, err)
 		}
 
 		keys := make(map[string]string, len(keyOut.AccessKeyMetadata))
@@ -43,7 +44,7 @@ func (s *S3Repository) ListUsers(ctx context.Context, id string) (map[string]int
 			keys[aws.StringValue(k.AccessKeyId)] = aws.StringValue(k.Status)
 		}
 
-		output[*u.UserName] = struct {
+		output[userName] = struct {
 			Keys map[string]string `json:"keys"`
 		}{keys}
 	}
@@ -113,7 +114,6 @@ func (s *S3Repository) CreateUser(ctx context.Context, id string) (interface{}, 
 		PolicyDocument: aws.String(string(policyDoc)),
 		PolicyName:     aws.String(name + "-DsTmpPlc"),
 	})
-
 	if err != nil {
 		return nil, ErrCode("create temporary access policy for dataset "+id, err)
 	}

--- a/s3datarepository/users.go
+++ b/s3datarepository/users.go
@@ -1,0 +1,447 @@
+package s3datarepository
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/YaleSpinup/ds-api/apierror"
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/iam"
+	"github.com/pkg/errors"
+	log "github.com/sirupsen/logrus"
+)
+
+func (s *S3Repository) ListUsers(ctx context.Context, id string) (map[string]interface{}, error) {
+	if id == "" {
+		return nil, apierror.New(apierror.ErrBadRequest, "invalid input", errors.New("empty id"))
+	}
+
+	name := id
+	if s.NamePrefix != "" {
+		name = s.NamePrefix + "-" + name
+	}
+
+	log.Infof("listing users of the s3datarepository %s", name)
+
+	groupName := fmt.Sprintf("%s-DsTmpGrp", name)
+	usersOutput, err := s.listGroupsUsers(ctx, groupName)
+	if err != nil {
+		return nil, err
+	}
+
+	log.Debugf("got iam users response %+v", usersOutput)
+
+	output := make(map[string]interface{}, len(usersOutput))
+	for _, u := range usersOutput {
+		keyOut, err := s.IAM.ListAccessKeysWithContext(ctx, &iam.ListAccessKeysInput{UserName: u.UserName})
+		if err != nil {
+			return nil, ErrCode("failed to getting access keys for user "+aws.StringValue(u.UserName), err)
+		}
+
+		keys := make(map[string]string, len(keyOut.AccessKeyMetadata))
+		for _, k := range keyOut.AccessKeyMetadata {
+			keys[aws.StringValue(k.AccessKeyId)] = aws.StringValue(k.Status)
+		}
+
+		output[*u.UserName] = struct {
+			Keys map[string]string `json:"keys"`
+		}{keys}
+	}
+
+	log.Debugf("returning map of users for dataset %s: %+v", id, output)
+
+	return output, nil
+}
+
+// listGroupsUsers lists the users that belong to a group
+func (s *S3Repository) listGroupsUsers(ctx context.Context, groupName string) ([]*iam.User, error) {
+	users := []*iam.User{}
+	if groupName == "" {
+		return users, apierror.New(apierror.ErrBadRequest, "invalid input", errors.New("empty group name"))
+	}
+
+	log.Infof("listing iam users for group %s", groupName)
+
+	input := &iam.GetGroupInput{GroupName: aws.String(groupName)}
+
+	truncated := true
+	for truncated {
+		output, err := s.IAM.GetGroupWithContext(ctx, input)
+		if err != nil {
+			return users, ErrCode("failed to getting users for group "+groupName, err)
+		}
+
+		truncated = aws.BoolValue(output.IsTruncated)
+		users = append(users, output.Users...)
+		input.Marker = output.Marker
+	}
+
+	return users, nil
+}
+
+func (s *S3Repository) CreateUser(ctx context.Context, id string) (interface{}, error) {
+	if id == "" {
+		return nil, apierror.New(apierror.ErrBadRequest, "invalid input", errors.New("empty id"))
+	}
+
+	name := id
+	if s.NamePrefix != "" {
+		name = s.NamePrefix + "-" + name
+	}
+
+	log.Infof("creating user of the s3datarepository %s", name)
+
+	policyDoc, err := s.temporaryAccessPolicy(id)
+	if err != nil {
+		return nil, ErrCode("generate temporary access policy for dataset "+id, err)
+	}
+
+	log.Debugf("generated temporary access policy document %s", string(policyDoc))
+
+	// setup rollback function list and defer execution
+	var rollBackTasks []func() error
+	defer func() {
+		if err != nil {
+			log.Errorf("recovering from error creating user in s3datarepository: %s, executing %d rollback tasks", err, len(rollBackTasks))
+			rollBack(&rollBackTasks)
+		}
+	}()
+
+	policyOutput, err := s.IAM.CreatePolicyWithContext(ctx, &iam.CreatePolicyInput{
+		Description:    aws.String("Temporary access policy for dataset " + id),
+		Path:           aws.String(s.IAMPathPrefix),
+		PolicyDocument: aws.String(string(policyDoc)),
+		PolicyName:     aws.String(name + "-DsTmpPlc"),
+	})
+
+	if err != nil {
+		return nil, ErrCode("create temporary access policy for dataset "+id, err)
+	}
+
+	if err := s.IAM.WaitUntilPolicyExistsWithContext(ctx, &iam.GetPolicyInput{PolicyArn: policyOutput.Policy.Arn}); err != nil {
+		return nil, ErrCode("waiting for temporary access policy to exist for dataset "+id, err)
+	}
+
+	// append policy delete to rollback tasks
+	rollBackTasks = append(rollBackTasks, func() error {
+		return func() error {
+			if _, err := s.IAM.DeletePolicyWithContext(ctx, &iam.DeletePolicyInput{PolicyArn: policyOutput.Policy.Arn}); err != nil {
+				return err
+			}
+			return nil
+		}()
+	})
+
+	log.Debugf("got iam create policy response %+v", policyOutput)
+
+	groupName := name + "-DsTmpGrp"
+	groupOutput, err := s.IAM.CreateGroupWithContext(ctx, &iam.CreateGroupInput{
+		GroupName: aws.String(groupName),
+		Path:      aws.String(s.IAMPathPrefix),
+	})
+	if err != nil {
+		return nil, ErrCode("create group for dataset "+id, err)
+	}
+
+	// append group delete to rollback tasks
+	rollBackTasks = append(rollBackTasks, func() error {
+		return func() error {
+			if _, err := s.IAM.DeleteGroupWithContext(ctx, &iam.DeleteGroupInput{GroupName: aws.String(groupName)}); err != nil {
+				return err
+			}
+			return nil
+		}()
+	})
+
+	log.Debugf("got iam create group response %+v", groupOutput)
+
+	if _, err = s.IAM.AttachGroupPolicyWithContext(ctx, &iam.AttachGroupPolicyInput{
+		GroupName: aws.String(groupName),
+		PolicyArn: policyOutput.Policy.Arn,
+	}); err != nil {
+		return nil, ErrCode("attach policy to group for dataset "+id, err)
+	}
+
+	// append policy detach to rollback tasks
+	rollBackTasks = append(rollBackTasks, func() error {
+		return func() error {
+			if _, err := s.IAM.DetachGroupPolicyWithContext(ctx, &iam.DetachGroupPolicyInput{
+				GroupName: aws.String(groupName),
+				PolicyArn: policyOutput.Policy.Arn,
+			}); err != nil {
+				return err
+			}
+			return nil
+		}()
+	})
+
+	userName := name + "-DsTmpUsr"
+	userOutput, err := s.IAM.CreateUserWithContext(ctx, &iam.CreateUserInput{
+		Path:     aws.String(s.IAMPathPrefix),
+		UserName: aws.String(userName),
+	})
+	if err != nil {
+		return nil, ErrCode("create user for dataset "+id, err)
+	}
+
+	if err := s.IAM.WaitUntilUserExistsWithContext(ctx, &iam.GetUserInput{UserName: aws.String(userName)}); err != nil {
+		return nil, ErrCode("waiting for user to exist for dataset "+id, err)
+	}
+
+	// append user delete to rollback tasks
+	rollBackTasks = append(rollBackTasks, func() error {
+		return func() error {
+			if _, err := s.IAM.DeleteUserWithContext(ctx, &iam.DeleteUserInput{
+				UserName: aws.String(userName),
+			}); err != nil {
+				return err
+			}
+			return nil
+		}()
+	})
+
+	log.Debugf("got iam create user response %+v", userOutput)
+
+	keyOutput, err := s.IAM.CreateAccessKeyWithContext(ctx, &iam.CreateAccessKeyInput{
+		UserName: aws.String(userName),
+	})
+	if err != nil {
+		return nil, ErrCode("create user access key for dataset "+id, err)
+	}
+
+	// append user delete to rollback tasks
+	rollBackTasks = append(rollBackTasks, func() error {
+		return func() error {
+			if _, err := s.IAM.DeleteAccessKeyWithContext(ctx, &iam.DeleteAccessKeyInput{
+				UserName:    aws.String(userName),
+				AccessKeyId: keyOutput.AccessKey.AccessKeyId,
+			}); err != nil {
+				return err
+			}
+			return nil
+		}()
+	})
+
+	if _, err = s.IAM.AddUserToGroupWithContext(ctx, &iam.AddUserToGroupInput{
+		GroupName: aws.String(groupName),
+		UserName:  aws.String(userName),
+	}); err != nil {
+		return nil, ErrCode("add user to group for dataset "+id, err)
+	}
+
+	log.Debugf("added user %s to group %s", userName, groupName)
+
+	output := struct {
+		Group       string            `json:"group"`
+		Policy      string            `json:"policy"`
+		User        string            `json:"user"`
+		Credentials map[string]string `json:"credentials"`
+	}{
+		Group:  groupName,
+		Policy: aws.StringValue(policyOutput.Policy.PolicyName),
+		User:   userName,
+		Credentials: map[string]string{
+			"akid":   aws.StringValue(keyOutput.AccessKey.AccessKeyId),
+			"secret": aws.StringValue(keyOutput.AccessKey.SecretAccessKey),
+		},
+	}
+
+	return output, nil
+}
+
+func (s *S3Repository) DeleteUser(ctx context.Context, id string) error {
+	if id == "" {
+		return apierror.New(apierror.ErrBadRequest, "invalid input", errors.New("empty id"))
+	}
+
+	name := id
+	if s.NamePrefix != "" {
+		name = s.NamePrefix + "-" + name
+	}
+
+	log.Infof("deleting user of the s3datarepository %s", name)
+
+	groupName := name + "-DsTmpGrp"
+	group, err := s.IAM.GetGroupWithContext(ctx, &iam.GetGroupInput{
+		GroupName: aws.String(groupName),
+	})
+	if err != nil {
+		return ErrCode("getting group for dataset "+id, err)
+	}
+
+	log.Debugf("found group '%s' %+v", groupName, group)
+
+	groupPolicies, err := s.IAM.ListAttachedGroupPoliciesWithContext(ctx, &iam.ListAttachedGroupPoliciesInput{
+		GroupName:  aws.String(groupName),
+		PathPrefix: aws.String(s.IAMPathPrefix),
+	})
+	if err != nil {
+		return ErrCode("listing attached group policies for dataset "+id, err)
+	}
+
+	log.Debugf("found attached group policies for '%s' %+v", groupName, groupPolicies)
+
+	policyName := name + "-DsTmpPlc"
+	for _, p := range groupPolicies.AttachedPolicies {
+		log.Debugf("detaching policy %s from group %s", aws.StringValue(p.PolicyName), groupName)
+		if _, err := s.IAM.DetachGroupPolicyWithContext(ctx, &iam.DetachGroupPolicyInput{
+			GroupName: aws.String(groupName),
+			PolicyArn: p.PolicyArn,
+		}); err != nil {
+			return ErrCode("detaching group policies for dataset "+id, err)
+		}
+
+		if aws.StringValue(p.PolicyName) == policyName {
+			log.Debugf("deleting policy %s", policyName)
+			if _, err := s.IAM.DeletePolicyWithContext(ctx, &iam.DeletePolicyInput{
+				PolicyArn: p.PolicyArn,
+			}); err != nil {
+				return ErrCode("deleting policy for dataset "+id, err)
+			}
+		}
+	}
+
+	userName := name + "-DsTmpUsr"
+	for _, u := range group.Users {
+		log.Debugf("removing user %s from group %s", aws.StringValue(u.UserName), groupName)
+		if _, err := s.IAM.RemoveUserFromGroupWithContext(ctx, &iam.RemoveUserFromGroupInput{
+			GroupName: aws.String(groupName),
+			UserName:  u.UserName,
+		}); err != nil {
+			return ErrCode("removing user from group for dataset "+id, err)
+		}
+
+		if aws.StringValue(u.UserName) == userName {
+			keyOut, err := s.IAM.ListAccessKeysWithContext(ctx, &iam.ListAccessKeysInput{
+				UserName: aws.String(userName),
+			})
+			if err != nil {
+				return ErrCode("listing user access keys for dataset "+id, err)
+			}
+
+			for _, k := range keyOut.AccessKeyMetadata {
+				log.Debugf("deleting user %s access key %s (%s)", userName, aws.StringValue(k.AccessKeyId), aws.StringValue(k.Status))
+				if _, err := s.IAM.DeleteAccessKeyWithContext(ctx, &iam.DeleteAccessKeyInput{
+					AccessKeyId: k.AccessKeyId,
+					UserName:    aws.String(userName),
+				}); err != nil {
+					return ErrCode("deleting user access key for dataset "+id, err)
+				}
+			}
+
+			log.Debugf("deleting user %s", userName)
+			if _, err := s.IAM.DeleteUserWithContext(ctx, &iam.DeleteUserInput{
+				UserName: aws.String(userName),
+			}); err != nil {
+				return ErrCode("deleting user for dataset "+id, err)
+			}
+
+		}
+	}
+
+	if _, err := s.IAM.DeleteGroupWithContext(ctx, &iam.DeleteGroupInput{
+		GroupName: aws.String(groupName),
+	}); err != nil {
+		return ErrCode("deleting group for dataset "+id, err)
+	}
+
+	return nil
+}
+
+// UpdateUser manages the user keys.  This function should step through the lifecycle of a user's keys for a dataset...
+// Provision key1 --> Provision key2, Make key1 Inactive --> Make key2 Inactive, Lock key generation.
+//
+// If there are no keys, one is created and made active. If there is one key, a new 'Active' key is generated. If
+// there are 'Active keys all are made 'Inactive'. If there are two 'Inactive' keys, an error is returned to the caller.
+// At any time, a user *should* only have one Active key.  Once the limit of two (2) keys is reached, manual intervention
+// is required to regain access to the dataset via these credentials.
+func (s *S3Repository) UpdateUser(ctx context.Context, id string) (map[string]interface{}, error) {
+	if id == "" {
+		return nil, apierror.New(apierror.ErrBadRequest, "invalid input", errors.New("empty id"))
+	}
+
+	name := id
+	if s.NamePrefix != "" {
+		name = s.NamePrefix + "-" + name
+	}
+
+	log.Infof("updating user of the s3datarepository %s", name)
+
+	userName := name + "-DsTmpUsr"
+	keysOut, err := s.IAM.ListAccessKeysWithContext(ctx, &iam.ListAccessKeysInput{
+		UserName: aws.String(userName),
+	})
+	if err != nil {
+		return nil, ErrCode("listing user access keys for dataset "+id, err)
+	}
+
+	log.Debugf("got user access keys output %+v", keysOut)
+
+	// setup rollback function list and defer execution
+	var rollBackTasks []func() error
+	defer func() {
+		if err != nil {
+			log.Errorf("recovering from error updating user in s3datarepository: %s, executing %d rollback tasks", err, len(rollBackTasks))
+			rollBack(&rollBackTasks)
+		}
+	}()
+
+	output := make(map[string]interface{})
+	if len(keysOut.AccessKeyMetadata) < 2 {
+		keyOut, err := s.IAM.CreateAccessKeyWithContext(ctx, &iam.CreateAccessKeyInput{
+			UserName: aws.String(userName),
+		})
+		if err != nil {
+			return nil, ErrCode("create user access key for dataset "+id, err)
+		}
+
+		output["credentials"] = struct {
+			KeyId  string `json:"akid"`
+			Secret string `json:"secret"`
+		}{
+			aws.StringValue(keyOut.AccessKey.AccessKeyId),
+			aws.StringValue(keyOut.AccessKey.SecretAccessKey),
+		}
+
+		// append user delete to rollback tasks
+		rollBackTasks = append(rollBackTasks, func() error {
+			return func() error {
+				if _, err := s.IAM.DeleteAccessKeyWithContext(ctx, &iam.DeleteAccessKeyInput{
+					UserName:    aws.String(userName),
+					AccessKeyId: keyOut.AccessKey.AccessKeyId,
+				}); err != nil {
+					return err
+				}
+				return nil
+			}()
+		})
+	}
+
+	var inactive int
+	keys := map[string]string{}
+	for _, k := range keysOut.AccessKeyMetadata {
+		if aws.StringValue(k.Status) == "Inactive" {
+			inactive += 1
+		}
+
+		keys[aws.StringValue(k.AccessKeyId)] = aws.StringValue(k.Status)
+		if aws.StringValue(k.Status) == "Active" {
+			log.Debugf("deactivating access key %s for dataset %s", aws.StringValue(k.AccessKeyId), id)
+			if _, err := s.IAM.UpdateAccessKeyWithContext(ctx, &iam.UpdateAccessKeyInput{
+				AccessKeyId: k.AccessKeyId,
+				Status:      aws.String("Inactive"),
+				UserName:    aws.String(userName),
+			}); err != nil {
+				return nil, ErrCode("deactivating user access key for dataset "+id, err)
+			}
+			keys[aws.StringValue(k.AccessKeyId)] = "Inactive"
+		}
+	}
+	output["keys"] = keys
+
+	if inactive >= 2 {
+		return nil, apierror.New(apierror.ErrLimitExceeded, "too many access keys (2)", nil)
+	}
+
+	return output, nil
+}

--- a/s3datarepository/users.go
+++ b/s3datarepository/users.go
@@ -37,7 +37,7 @@ func (s *S3Repository) ListUsers(ctx context.Context, id string) (map[string]int
 		userName := aws.StringValue(u.UserName)
 		keyOut, err := s.IAM.ListAccessKeysWithContext(ctx, &iam.ListAccessKeysInput{UserName: u.UserName})
 		if err != nil {
-			return nil, ErrCode("failed to getting access keys for user "+userName, err)
+			return nil, ErrCode("failed getting access keys for user "+userName, err)
 		}
 
 		keys := make(map[string]string, len(keyOut.AccessKeyMetadata))
@@ -70,7 +70,7 @@ func (s *S3Repository) listGroupsUsers(ctx context.Context, groupName string) ([
 	for truncated {
 		output, err := s.IAM.GetGroupWithContext(ctx, input)
 		if err != nil {
-			return users, ErrCode("failed to getting users for group "+groupName, err)
+			return users, ErrCode("failed getting users for group "+groupName, err)
 		}
 
 		truncated = aws.BoolValue(output.IsTruncated)

--- a/s3datarepository/users_test.go
+++ b/s3datarepository/users_test.go
@@ -497,7 +497,7 @@ func TestListUsers(t *testing.T) {
 					accessKeys: []*iam.AccessKeyMetadata{},
 				},
 			},
-			err: errors.New("InternalError: failed getting access keys for user dataset-6639faf1-b9a2-4882-b4ff-36b429a80c6f-DsTmpUsr (TestListUsers ListAccessKeysWithContext)"),
+			err: errors.New("InternalError: failed to get access keys for user dataset-6639faf1-b9a2-4882-b4ff-36b429a80c6f-DsTmpUsr (TestListUsers ListAccessKeysWithContext)"),
 			merr: map[string]error{
 				"ListAccessKeysWithContext": errors.New("TestListUsers ListAccessKeysWithContext"),
 			},
@@ -580,7 +580,7 @@ func TestListGroupUsers(t *testing.T) {
 					accessKeys: []*iam.AccessKeyMetadata{},
 				},
 			},
-			err: errors.New("InternalError: failed getting users for group dataset-1d210026-3696-4268-89e6-f20cfe7128ad-DsTmpGrp (TestListGroupUsers GetGroupWithContext)"),
+			err: errors.New("InternalError: failed to get users for group dataset-1d210026-3696-4268-89e6-f20cfe7128ad-DsTmpGrp (TestListGroupUsers GetGroupWithContext)"),
 			merr: map[string]error{
 				"GetGroupWithContext": errors.New("TestListGroupUsers GetGroupWithContext"),
 			},
@@ -649,7 +649,7 @@ func TestCreateUser(t *testing.T) {
 					accessKeys: []*iam.AccessKeyMetadata{},
 				},
 			},
-			err: errors.New("InternalError: waiting for temporary access policy to exist for dataset 47db569b-06fc-4679-8a17-57fe2506d6d7 (TestCreateUser WaitUntilPolicyExistsWithContext)"),
+			err: errors.New("InternalError: failed waiting for temporary access policy to exist for dataset 47db569b-06fc-4679-8a17-57fe2506d6d7 (TestCreateUser WaitUntilPolicyExistsWithContext)"),
 			merr: map[string]error{
 				"WaitUntilPolicyExistsWithContext": errors.New("TestCreateUser WaitUntilPolicyExistsWithContext"),
 			},
@@ -670,7 +670,7 @@ func TestCreateUser(t *testing.T) {
 					accessKeys: []*iam.AccessKeyMetadata{},
 				},
 			},
-			err: errors.New("InternalError: create group for dataset 3fad3da9-b485-4e19-a71d-77bb638964ed (TestCreateUser CreateGroupWithContext)"),
+			err: errors.New("InternalError: failed to create group for dataset 3fad3da9-b485-4e19-a71d-77bb638964ed (TestCreateUser CreateGroupWithContext)"),
 			merr: map[string]error{
 				"CreateGroupWithContext": errors.New("TestCreateUser CreateGroupWithContext"),
 			},
@@ -691,7 +691,7 @@ func TestCreateUser(t *testing.T) {
 					accessKeys: []*iam.AccessKeyMetadata{},
 				},
 			},
-			err: errors.New("InternalError: attach policy to group for dataset 8462a15d-5456-4ec2-98ee-c6a3a9a055e9 (TestCreateUser AttachGroupPolicyWithContext)"),
+			err: errors.New("InternalError: failed to attach policy to group for dataset 8462a15d-5456-4ec2-98ee-c6a3a9a055e9 (TestCreateUser AttachGroupPolicyWithContext)"),
 			merr: map[string]error{
 				"AttachGroupPolicyWithContext": errors.New("TestCreateUser AttachGroupPolicyWithContext"),
 			},
@@ -712,7 +712,7 @@ func TestCreateUser(t *testing.T) {
 					accessKeys: []*iam.AccessKeyMetadata{},
 				},
 			},
-			err: errors.New("InternalError: create user for dataset 5a1a1e09-a837-4b4e-84fd-0fb47d14b7fe (TestCreateUser CreateUserWithContext)"),
+			err: errors.New("InternalError: failed to create user for dataset 5a1a1e09-a837-4b4e-84fd-0fb47d14b7fe (TestCreateUser CreateUserWithContext)"),
 			merr: map[string]error{
 				"CreateUserWithContext": errors.New("TestCreateUser CreateUserWithContext"),
 			},
@@ -733,7 +733,7 @@ func TestCreateUser(t *testing.T) {
 					accessKeys: []*iam.AccessKeyMetadata{},
 				},
 			},
-			err: errors.New("InternalError: waiting for user to exist for dataset 8447af60-1174-49a0-bc06-3ea18755fa25 (TestCreateUser WaitUntilUserExistsWithContext)"),
+			err: errors.New("InternalError: failed waiting for user to exist for dataset 8447af60-1174-49a0-bc06-3ea18755fa25 (TestCreateUser WaitUntilUserExistsWithContext)"),
 			merr: map[string]error{
 				"WaitUntilUserExistsWithContext": errors.New("TestCreateUser WaitUntilUserExistsWithContext"),
 			},
@@ -754,7 +754,7 @@ func TestCreateUser(t *testing.T) {
 					accessKeys: []*iam.AccessKeyMetadata{},
 				},
 			},
-			err: errors.New("InternalError: create user access key for dataset 0d987a82-fa02-420b-8ea0-46d4d63a86a6 (TestCreateUser CreateAccessKeyWithContext)"),
+			err: errors.New("InternalError: failed to create user access key for dataset 0d987a82-fa02-420b-8ea0-46d4d63a86a6 (TestCreateUser CreateAccessKeyWithContext)"),
 			merr: map[string]error{
 				"CreateAccessKeyWithContext": errors.New("TestCreateUser CreateAccessKeyWithContext"),
 			},
@@ -775,7 +775,7 @@ func TestCreateUser(t *testing.T) {
 					accessKeys: []*iam.AccessKeyMetadata{},
 				},
 			},
-			err: errors.New("InternalError: add user to group for dataset 3830f909-bfd7-4bae-87bd-cf9f0aeeac20 (TestCreateUser AddUserToGroupWithContext)"),
+			err: errors.New("InternalError: failed to add user to group for dataset 3830f909-bfd7-4bae-87bd-cf9f0aeeac20 (TestCreateUser AddUserToGroupWithContext)"),
 			merr: map[string]error{
 				"AddUserToGroupWithContext": errors.New("TestCreateUser AddUserToGroupWithContext"),
 			},
@@ -894,7 +894,7 @@ func TestUpdateUser(t *testing.T) {
 					accessKeys: []*iam.AccessKeyMetadata{},
 				},
 			},
-			err: errors.New("InternalError: listing user access keys for dataset 091faadd-b8b8-449c-a6ba-88f9c5020556 (TestUpdateUser ListAccessKeysWithContext)"),
+			err: errors.New("InternalError: failed to list user access keys for dataset 091faadd-b8b8-449c-a6ba-88f9c5020556 (TestUpdateUser ListAccessKeysWithContext)"),
 			merr: map[string]error{
 				"ListAccessKeysWithContext": errors.New("TestUpdateUser ListAccessKeysWithContext"),
 			},
@@ -915,7 +915,7 @@ func TestUpdateUser(t *testing.T) {
 					accessKeys: []*iam.AccessKeyMetadata{},
 				},
 			},
-			err: errors.New("InternalError: create user access key for dataset 9e0f9251-9672-40dc-85b0-05cc2e146f30 (TestUpdateUser CreateAccessKeyWithContext)"),
+			err: errors.New("InternalError: failed to create user access key for dataset 9e0f9251-9672-40dc-85b0-05cc2e146f30 (TestUpdateUser CreateAccessKeyWithContext)"),
 			merr: map[string]error{
 				"CreateAccessKeyWithContext": errors.New("TestUpdateUser CreateAccessKeyWithContext"),
 			},
@@ -941,7 +941,7 @@ func TestUpdateUser(t *testing.T) {
 					},
 				},
 			},
-			err: errors.New("InternalError: deactivating user access key for dataset 8b17eea2-2afe-4eaf-9c1f-efe0f210c387 (TestUpdateUser UpdateAccessKeyWithContext)"),
+			err: errors.New("InternalError: failed to deactivate user access key for dataset 8b17eea2-2afe-4eaf-9c1f-efe0f210c387 (TestUpdateUser UpdateAccessKeyWithContext)"),
 			merr: map[string]error{
 				"UpdateAccessKeyWithContext": errors.New("TestUpdateUser UpdateAccessKeyWithContext"),
 			},

--- a/s3datarepository/users_test.go
+++ b/s3datarepository/users_test.go
@@ -1,0 +1,1022 @@
+package s3datarepository
+
+import (
+	"context"
+	"fmt"
+	"reflect"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/aws/aws-sdk-go/aws/request"
+	"github.com/aws/aws-sdk-go/service/iam"
+	"github.com/pkg/errors"
+)
+
+func (m *mockIAMClient) AddUserToGroupWithContext(ctx context.Context, input *iam.AddUserToGroupInput, opts ...request.Option) (*iam.AddUserToGroupOutput, error) {
+	if err, ok := m.err["AddUserToGroupWithContext"]; ok && err != nil {
+		return nil, err
+	}
+
+	m.t.Logf("AddUserToGroupWithContext: %+v", input)
+
+	for _, tds := range testDatasets {
+		if aws.StringValue(tds.group.group.GroupName) == aws.StringValue(input.GroupName) {
+			for _, tu := range tds.users {
+				if aws.StringValue(input.UserName) == aws.StringValue(tu.user.UserName) {
+					return &iam.AddUserToGroupOutput{}, nil
+				}
+			}
+		}
+	}
+
+	return nil, awserr.New(iam.ErrCodeNoSuchEntityException, "The group cannot be found.", nil)
+}
+
+func (m *mockIAMClient) AttachGroupPolicyWithContext(ctx context.Context, input *iam.AttachGroupPolicyInput, opts ...request.Option) (*iam.AttachGroupPolicyOutput, error) {
+	if err, ok := m.err["AttachGroupPolicyWithContext"]; ok && err != nil {
+		return nil, err
+	}
+
+	m.t.Logf("AttachGroupPolicyWithContext: %+v", input)
+
+	for _, tds := range testDatasets {
+		if tds.group == nil || tds.group.group == nil {
+			continue
+		}
+
+		if aws.StringValue(input.GroupName) == aws.StringValue(tds.group.group.GroupName) {
+			pArn := fmt.Sprintf("arn:aws:iam::12345678901:policy/test/dataset-%s-DsTmpPlc", tds.id)
+			if aws.StringValue(input.PolicyArn) != pArn {
+				return nil, awserr.New(iam.ErrCodeNoSuchEntityException, " The iam policy cannot be found.", nil)
+			}
+			return &iam.AttachGroupPolicyOutput{}, nil
+		}
+	}
+
+	return nil, awserr.New(iam.ErrCodeNoSuchEntityException, "The group cannot be found.", nil)
+}
+
+func (m *mockIAMClient) CreateAccessKeyWithContext(ctx context.Context, input *iam.CreateAccessKeyInput, opts ...request.Option) (*iam.CreateAccessKeyOutput, error) {
+	if err, ok := m.err["CreateAccessKeyWithContext"]; ok && err != nil {
+		return nil, err
+	}
+
+	m.t.Logf("CreateAccessKeyWithContext: %+v", input)
+
+	for _, tds := range testDatasets {
+		for _, u := range tds.users {
+			if aws.StringValue(input.UserName) == aws.StringValue(u.user.UserName) {
+				return &iam.CreateAccessKeyOutput{
+					AccessKey: &iam.AccessKey{
+						AccessKeyId:     aws.String(aws.StringValue(input.UserName) + "KEY"),
+						SecretAccessKey: aws.String(aws.StringValue(input.UserName) + "SECRET"),
+					},
+				}, nil
+			}
+		}
+	}
+
+	return nil, awserr.New(iam.ErrCodeNoSuchEntityException, "The user cannot be found.", nil)
+}
+
+func (m *mockIAMClient) CreateGroupWithContext(ctx context.Context, input *iam.CreateGroupInput, opts ...request.Option) (*iam.CreateGroupOutput, error) {
+	if err, ok := m.err["CreateGroupWithContext"]; ok && err != nil {
+		return nil, err
+	}
+
+	m.t.Logf("CreateGroupWithContext: %+v", input)
+
+	for _, tds := range testDatasets {
+		m.t.Logf("testing tds: %+v", tds)
+
+		if tds.group == nil || tds.group.group == nil {
+			continue
+		}
+
+		if aws.StringValue(input.GroupName) == aws.StringValue(tds.group.group.GroupName) {
+			return &iam.CreateGroupOutput{
+				Group: tds.group.group,
+			}, nil
+		}
+	}
+
+	return nil, awserr.New(iam.ErrCodeNoSuchEntityException, "The group cannot be found.", nil)
+}
+
+func (m *mockIAMClient) CreateUserWithContext(ctx context.Context, input *iam.CreateUserInput, opts ...request.Option) (*iam.CreateUserOutput, error) {
+	if err, ok := m.err["CreateUserWithContext"]; ok && err != nil {
+		return nil, err
+	}
+
+	m.t.Logf("CreateUserWithContext: %+v", input)
+
+	for _, tds := range testDatasets {
+		for _, u := range tds.users {
+			if aws.StringValue(input.UserName) == aws.StringValue(u.user.UserName) {
+				return &iam.CreateUserOutput{
+					User: u.user,
+				}, nil
+			}
+		}
+	}
+
+	return nil, awserr.New(iam.ErrCodeNoSuchEntityException, "The user cannot be found.", nil)
+}
+
+func (m *mockIAMClient) DeleteAccessKeyWithContext(ctx context.Context, input *iam.DeleteAccessKeyInput, opts ...request.Option) (*iam.DeleteAccessKeyOutput, error) {
+	if err, ok := m.err["DeleteAccessKeyWithContext"]; ok && err != nil {
+		return nil, err
+	}
+
+	m.t.Logf("DeleteAccessKeyWithContext: %+v", input)
+
+	for _, tds := range testDatasets {
+		for _, u := range tds.users {
+			if aws.StringValue(input.UserName) == aws.StringValue(u.user.UserName) {
+				for _, k := range u.accessKeys {
+					if aws.StringValue(k.AccessKeyId) == aws.StringValue(input.AccessKeyId) {
+						return &iam.DeleteAccessKeyOutput{}, nil
+					}
+				}
+			}
+		}
+	}
+
+	return nil, awserr.New(iam.ErrCodeNoSuchEntityException, "The user cannot be found.", nil)
+}
+
+func (m *mockIAMClient) DeleteGroupWithContext(ctx context.Context, input *iam.DeleteGroupInput, opts ...request.Option) (*iam.DeleteGroupOutput, error) {
+	if err, ok := m.err["DeleteGroupWithContext"]; ok && err != nil {
+		return nil, err
+	}
+
+	m.t.Logf("DeleteGroupWithContext: %+v", input)
+
+	for _, tds := range testDatasets {
+		if tds.group == nil || tds.group.group == nil {
+			continue
+		}
+
+		if aws.StringValue(tds.group.group.GroupName) == aws.StringValue(input.GroupName) {
+			return &iam.DeleteGroupOutput{}, nil
+		}
+	}
+
+	return nil, awserr.New("Forbidden", "No access to group", nil)
+}
+
+func (m *mockIAMClient) DeleteUserWithContext(ctx context.Context, input *iam.DeleteUserInput, opts ...request.Option) (*iam.DeleteUserOutput, error) {
+	if err, ok := m.err["DeleteUserWithContext"]; ok && err != nil {
+		return nil, err
+	}
+
+	m.t.Logf("DeleteUserWithContext: %+v", input)
+
+	for _, tds := range testDatasets {
+		for _, u := range tds.users {
+			if aws.StringValue(input.UserName) == aws.StringValue(u.user.UserName) {
+				return &iam.DeleteUserOutput{}, nil
+			}
+		}
+	}
+
+	return nil, awserr.New(iam.ErrCodeNoSuchEntityException, "The user cannot be found.", nil)
+}
+
+func (m *mockIAMClient) DetachGroupPolicyWithContext(ctx context.Context, input *iam.DetachGroupPolicyInput, opts ...request.Option) (*iam.DetachGroupPolicyOutput, error) {
+	if err, ok := m.err["DetachGroupPolicyWithContext"]; ok && err != nil {
+		return nil, err
+	}
+
+	m.t.Logf("DetachGroupPolicyWithContext: %+v", input)
+
+	for _, tds := range testDatasets {
+		if tds.group == nil || tds.group.group == nil {
+			continue
+		}
+
+		if aws.StringValue(input.GroupName) == aws.StringValue(tds.group.group.GroupName) {
+			pArn := fmt.Sprintf("arn:aws:iam::12345678901:policy/test/dataset-%s-DsTmpPlc", tds.id)
+			if aws.StringValue(input.PolicyArn) != pArn {
+				return nil, awserr.New(iam.ErrCodeNoSuchEntityException, "The iam policy cannot be found.", nil)
+			}
+			return &iam.DetachGroupPolicyOutput{}, nil
+		}
+	}
+
+	return nil, awserr.New(iam.ErrCodeNoSuchEntityException, "The group cannot be found.", nil)
+
+}
+
+func (m *mockIAMClient) GetGroupWithContext(ctx context.Context, input *iam.GetGroupInput, opts ...request.Option) (*iam.GetGroupOutput, error) {
+	if err, ok := m.err["GetGroupWithContext"]; ok && err != nil {
+		return nil, err
+	}
+
+	m.t.Logf("GetGroupWithContext: %+v", input)
+
+	for _, tds := range testDatasets {
+		if tds.group == nil || tds.group.group == nil {
+			continue
+		}
+
+		if aws.StringValue(tds.group.group.GroupName) == aws.StringValue(input.GroupName) {
+			output := &iam.GetGroupOutput{
+				Group: tds.group.group,
+				Users: []*iam.User{},
+			}
+
+			for _, u := range tds.users {
+				output.Users = append(output.Users, u.user)
+			}
+
+			return output, nil
+		}
+	}
+
+	return nil, awserr.New("Forbidden", "No access to group", nil)
+}
+
+func (m *mockIAMClient) ListAccessKeysWithContext(ctx context.Context, input *iam.ListAccessKeysInput, opts ...request.Option) (*iam.ListAccessKeysOutput, error) {
+	if err, ok := m.err["ListAccessKeysWithContext"]; ok && err != nil {
+		return nil, err
+	}
+
+	m.t.Logf("ListAccessKeysWithContext: %+v", input)
+
+	output := &iam.ListAccessKeysOutput{}
+	for _, tds := range testDatasets {
+		for _, u := range tds.users {
+			if aws.StringValue(input.UserName) == aws.StringValue(u.user.UserName) {
+				output.AccessKeyMetadata = u.accessKeys
+			}
+		}
+	}
+
+	return output, nil
+}
+
+func (m *mockIAMClient) ListAttachedGroupPoliciesWithContext(ctx context.Context, input *iam.ListAttachedGroupPoliciesInput, opts ...request.Option) (*iam.ListAttachedGroupPoliciesOutput, error) {
+	if err, ok := m.err["ListAttachedGroupPoliciesWithContext"]; ok && err != nil {
+		return nil, err
+	}
+
+	m.t.Logf("ListAttachedGroupPoliciesWithContext: %+v", input)
+
+	for _, tds := range testDatasets {
+		if aws.StringValue(input.GroupName) == aws.StringValue(tds.group.group.GroupName) {
+			return &iam.ListAttachedGroupPoliciesOutput{
+				AttachedPolicies: []*iam.AttachedPolicy{
+					{
+						PolicyArn:  aws.String(fmt.Sprintf("arn:aws:iam::12345678901:policy/test/dataset-%s-DsTmpPlc", tds.id)),
+						PolicyName: aws.String(fmt.Sprintf("dataset-%s-DsTmpPlc", tds.id)),
+					},
+				},
+			}, nil
+		}
+	}
+
+	return nil, awserr.New(iam.ErrCodeNoSuchEntityException, "The group cannot be found.", nil)
+}
+
+func (m *mockIAMClient) RemoveUserFromGroupWithContext(ctx context.Context, input *iam.RemoveUserFromGroupInput, opts ...request.Option) (*iam.RemoveUserFromGroupOutput, error) {
+	if err, ok := m.err["RemoveUserFromGroupWithContext"]; ok && err != nil {
+		return nil, err
+	}
+
+	m.t.Logf("RemoveUserFromGroupWithContext: %+v", input)
+
+	for _, tds := range testDatasets {
+		if aws.StringValue(tds.group.group.GroupName) == aws.StringValue(input.GroupName) {
+			for _, tu := range tds.users {
+				if aws.StringValue(input.UserName) == aws.StringValue(tu.user.UserName) {
+					return &iam.RemoveUserFromGroupOutput{}, nil
+				}
+			}
+		}
+	}
+
+	return nil, awserr.New(iam.ErrCodeNoSuchEntityException, "The group cannot be found.", nil)
+}
+
+func (m *mockIAMClient) UpdateAccessKeyWithContext(ctx context.Context, input *iam.UpdateAccessKeyInput, opts ...request.Option) (*iam.UpdateAccessKeyOutput, error) {
+	if err, ok := m.err["UpdateAccessKeyWithContext"]; ok && err != nil {
+		return nil, err
+	}
+
+	m.t.Logf("UpdateAccessKeyWithContext: %+v", input)
+
+	for _, tds := range testDatasets {
+		for _, u := range tds.users {
+			if aws.StringValue(input.UserName) == aws.StringValue(u.user.UserName) {
+				for _, k := range u.accessKeys {
+					if aws.StringValue(k.AccessKeyId) == aws.StringValue(input.AccessKeyId) {
+						k.Status = input.Status
+						return &iam.UpdateAccessKeyOutput{}, nil
+					}
+				}
+			}
+		}
+	}
+
+	return nil, awserr.New(iam.ErrCodeNoSuchEntityException, "The user cannot be found.", nil)
+}
+
+func (m *mockIAMClient) WaitUntilPolicyExistsWithContext(ctx context.Context, input *iam.GetPolicyInput, opts ...request.WaiterOption) error {
+	if err, ok := m.err["WaitUntilPolicyExistsWithContext"]; ok && err != nil {
+		return err
+	}
+	return nil
+}
+
+func (m *mockIAMClient) WaitUntilUserExistsWithContext(ctx context.Context, input *iam.GetUserInput, opts ...request.WaiterOption) error {
+	if err, ok := m.err["WaitUntilUserExistsWithContext"]; ok && err != nil {
+		return err
+	}
+	return nil
+}
+
+type testUser struct {
+	user       *iam.User
+	accessKeys []*iam.AccessKeyMetadata
+}
+
+type testGroup struct {
+	group *iam.Group
+}
+
+type testDataset struct {
+	id    string
+	group *testGroup
+	users []*testUser
+	merr  map[string]error
+	err   error
+}
+
+var testDatasets []testDataset
+
+func newTestDatasets() []testDataset {
+	testDatasets = nil
+	return []testDataset{
+		{
+			id: "a44ef4bf-01ce-4073-a738-fa33792624ae",
+			group: &testGroup{
+				group: &iam.Group{
+					GroupName: aws.String("dataset-a44ef4bf-01ce-4073-a738-fa33792624ae-DsTmpGrp"),
+				},
+			},
+			users: []*testUser{
+				{
+					user: &iam.User{
+						Arn:      aws.String("arn:aws:iam::12345678901:users/dataset-a44ef4bf-01ce-4073-a738-fa33792624ae-DsTmpUsr"),
+						UserName: aws.String("dataset-a44ef4bf-01ce-4073-a738-fa33792624ae-DsTmpUsr"),
+					},
+					accessKeys: []*iam.AccessKeyMetadata{},
+				},
+			},
+		},
+		{
+			id: "b6977427-366f-46b7-881a-02452bf0110d",
+			group: &testGroup{
+				group: &iam.Group{
+					GroupName: aws.String("dataset-b6977427-366f-46b7-881a-02452bf0110d-DsTmpGrp"),
+				},
+			},
+			users: []*testUser{
+				{
+					user: &iam.User{
+						Arn:      aws.String("arn:aws:iam::12345678901:users/dataset-b6977427-366f-46b7-881a-02452bf0110d-DsTmpUsr"),
+						UserName: aws.String("dataset-b6977427-366f-46b7-881a-02452bf0110d-DsTmpUsr"),
+					},
+					accessKeys: []*iam.AccessKeyMetadata{
+						{
+							AccessKeyId: aws.String("ABCDEFG"),
+							Status:      aws.String("Active"),
+						},
+					},
+				},
+			},
+		},
+		{
+			id: "a485eb25-8346-4bd2-a540-867dff61aa7b",
+			group: &testGroup{
+				group: &iam.Group{
+					GroupName: aws.String("dataset-a485eb25-8346-4bd2-a540-867dff61aa7b-DsTmpGrp"),
+				},
+			},
+			users: []*testUser{
+				{
+					user: &iam.User{
+						Arn:      aws.String("arn:aws:iam::12345678901:users/dataset-a485eb25-8346-4bd2-a540-867dff61aa7b-DsTmpUsr"),
+						UserName: aws.String("dataset-a485eb25-8346-4bd2-a540-867dff61aa7b-DsTmpUsr"),
+					},
+					accessKeys: []*iam.AccessKeyMetadata{
+						{
+							AccessKeyId: aws.String("HIJKLMN"),
+							Status:      aws.String("Inactive"),
+						},
+					},
+				},
+			},
+		},
+		{
+			id: "9c9f2dbd-100c-4f8e-b4ad-03a399cd745a",
+			group: &testGroup{
+				group: &iam.Group{
+					GroupName: aws.String("dataset-9c9f2dbd-100c-4f8e-b4ad-03a399cd745a-DsTmpGrp"),
+				},
+			},
+			users: []*testUser{
+				{
+					user: &iam.User{
+						Arn:      aws.String("arn:aws:iam::12345678901:users/dataset-9c9f2dbd-100c-4f8e-b4ad-03a399cd745a-DsTmpUsr"),
+						UserName: aws.String("dataset-9c9f2dbd-100c-4f8e-b4ad-03a399cd745a-DsTmpUsr"),
+					},
+					accessKeys: []*iam.AccessKeyMetadata{
+						{
+							AccessKeyId: aws.String("OPQRSTUV"),
+							Status:      aws.String("Inactive"),
+						},
+						{
+							AccessKeyId: aws.String("WXYZ12"),
+							Status:      aws.String("Active"),
+						},
+					},
+				},
+			},
+		},
+		{
+			id: "c1fdc576-0467-474c-acb8-f6e35f75b8d3",
+			group: &testGroup{
+				group: &iam.Group{
+					GroupName: aws.String("dataset-c1fdc576-0467-474c-acb8-f6e35f75b8d3-DsTmpGrp"),
+				},
+			},
+			users: []*testUser{
+				{
+					user: &iam.User{
+						Arn:      aws.String("arn:aws:iam::12345678901:users/dataset-c1fdc576-0467-474c-acb8-f6e35f75b8d3-DsTmpUsr"),
+						UserName: aws.String("dataset-c1fdc576-0467-474c-acb8-f6e35f75b8d3-DsTmpUsr"),
+					},
+					accessKeys: []*iam.AccessKeyMetadata{
+						{
+							AccessKeyId: aws.String("3456789"),
+							Status:      aws.String("Inactive"),
+						},
+						{
+							AccessKeyId: aws.String("10111213"),
+							Status:      aws.String("Inactive"),
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func TestListUsers(t *testing.T) {
+	listUserErrTests := []testDataset{
+		{
+			id:  "",
+			err: errors.New("BadRequest: invalid input (empty id)"),
+		},
+		{
+			id: "6639faf1-b9a2-4882-b4ff-36b429a80c6f",
+			group: &testGroup{
+				group: &iam.Group{
+					GroupName: aws.String("dataset-6639faf1-b9a2-4882-b4ff-36b429a80c6f-DsTmpGrp"),
+				},
+			},
+			users: []*testUser{
+				{
+					user: &iam.User{
+						Arn:      aws.String("arn:aws:iam::12345678901:users/dataset-6639faf1-b9a2-4882-b4ff-36b429a80c6f-DsTmpUsr"),
+						UserName: aws.String("dataset-6639faf1-b9a2-4882-b4ff-36b429a80c6f-DsTmpUsr"),
+					},
+					accessKeys: []*iam.AccessKeyMetadata{},
+				},
+			},
+			err: errors.New("InternalError: failed getting access keys for user dataset-6639faf1-b9a2-4882-b4ff-36b429a80c6f-DsTmpUsr (TestListUsers ListAccessKeysWithContext)"),
+			merr: map[string]error{
+				"ListAccessKeysWithContext": errors.New("TestListUsers ListAccessKeysWithContext"),
+			},
+		},
+	}
+
+	testDatasets = append(newTestDatasets(), listUserErrTests...)
+
+	t.Logf("length of tests: %d", len(testDatasets))
+
+	for _, tds := range testDatasets {
+		s := newTestS3Repository(t)
+		if tds.merr != nil {
+			s.IAM.(*mockIAMClient).err = tds.merr
+			if _, err := s.ListUsers(context.TODO(), tds.id); err != nil {
+				if err.Error() != tds.err.Error() {
+					t.Errorf("expected error '%s', got '%s'", tds.err, err)
+				}
+			} else {
+				t.Error("expected error, got nil")
+			}
+		}
+
+		expected := make(map[string]interface{})
+		for _, u := range tds.users {
+			name := aws.StringValue(u.user.UserName)
+			keys := make(map[string]string)
+			for _, k := range u.accessKeys {
+				keys[aws.StringValue(k.AccessKeyId)] = aws.StringValue(k.Status)
+			}
+
+			expected[name] = struct {
+				Keys map[string]string `json:"keys"`
+			}{keys}
+		}
+
+		out, err := s.ListUsers(context.TODO(), tds.id)
+		if err != nil && tds.err == nil {
+			t.Errorf("expected nil error, got %s", err)
+		} else if err == nil && tds.err != nil {
+			t.Errorf("expected err %s, got nil", tds.err)
+		} else if err != nil {
+			if tds.err.Error() != err.Error() {
+				t.Errorf("expected error %s, got %s", tds.err, err)
+			}
+		} else {
+			t.Logf("got output %+v", out)
+
+			if !reflect.DeepEqual(expected, out) {
+				t.Errorf("expected %+v, got %+v", expected, out)
+			}
+		}
+	}
+}
+
+func TestListGroupUsers(t *testing.T) {
+	listGroupUserErrTests := []testDataset{
+		{
+			id: "d77a6341-8faa-4871-9c79-5f53e634045c",
+			group: &testGroup{
+				group: &iam.Group{
+					GroupName: aws.String(""),
+				},
+			},
+			err: errors.New("BadRequest: invalid input (empty group name)"),
+		},
+		{
+			id: "1d210026-3696-4268-89e6-f20cfe7128ad",
+			group: &testGroup{
+				group: &iam.Group{
+					GroupName: aws.String("dataset-1d210026-3696-4268-89e6-f20cfe7128ad-DsTmpGrp"),
+				},
+			},
+			users: []*testUser{
+				{
+					user: &iam.User{
+						Arn:      aws.String("arn:aws:iam::12345678901:users/dataset-61d210026-3696-4268-89e6-f20cfe7128ad-DsTmpUsr"),
+						UserName: aws.String("dataset-1d210026-3696-4268-89e6-f20cfe7128ad-DsTmpUsr"),
+					},
+					accessKeys: []*iam.AccessKeyMetadata{},
+				},
+			},
+			err: errors.New("InternalError: failed getting users for group dataset-1d210026-3696-4268-89e6-f20cfe7128ad-DsTmpGrp (TestListGroupUsers GetGroupWithContext)"),
+			merr: map[string]error{
+				"GetGroupWithContext": errors.New("TestListGroupUsers GetGroupWithContext"),
+			},
+		},
+	}
+	testDatasets = append(newTestDatasets(), listGroupUserErrTests...)
+
+	t.Logf("length of tests: %d", len(testDatasets))
+
+	for _, tds := range testDatasets {
+		s := newTestS3Repository(t)
+		if tds.merr != nil {
+			s.IAM.(*mockIAMClient).err = tds.merr
+			if _, err := s.listGroupsUsers(context.TODO(), aws.StringValue(tds.group.group.GroupName)); err != nil {
+				if err.Error() != tds.err.Error() {
+					t.Errorf("expected error '%s', got '%s'", tds.err, err)
+				}
+			} else {
+				t.Error("expected error, got nil")
+			}
+		}
+
+		expected := []*iam.User{}
+		for _, u := range tds.users {
+			expected = append(expected, u.user)
+		}
+
+		out, err := s.listGroupsUsers(context.TODO(), aws.StringValue(tds.group.group.GroupName))
+		if err != nil && tds.err == nil {
+			t.Errorf("expected nil error, got %s", err)
+		} else if err == nil && tds.err != nil {
+			t.Errorf("expected err %s, got nil", tds.err)
+		} else if err != nil {
+			if tds.err.Error() != err.Error() {
+				t.Errorf("expected error %s, got %s", tds.err, err)
+			}
+		} else {
+			t.Logf("got output %+v", out)
+
+			if !reflect.DeepEqual(expected, out) {
+				t.Errorf("expected %+v, got %+v", expected, out)
+			}
+		}
+	}
+}
+
+func TestCreateUser(t *testing.T) {
+	createUserErrTests := []testDataset{
+		{
+			id:  "",
+			err: errors.New("BadRequest: invalid input (empty id)"),
+		},
+		{
+			id: "47db569b-06fc-4679-8a17-57fe2506d6d7",
+			group: &testGroup{
+				group: &iam.Group{
+					GroupName: aws.String("dataset-47db569b-06fc-4679-8a17-57fe2506d6d7-DsTmpGrp"),
+				},
+			},
+			users: []*testUser{
+				{
+					user: &iam.User{
+						Arn:      aws.String("arn:aws:iam::12345678901:users/dataset-47db569b-06fc-4679-8a17-57fe2506d6d7-DsTmpUsr"),
+						UserName: aws.String("dataset-47db569b-06fc-4679-8a17-57fe2506d6d7-DsTmpUsr"),
+					},
+					accessKeys: []*iam.AccessKeyMetadata{},
+				},
+			},
+			err: errors.New("InternalError: waiting for temporary access policy to exist for dataset 47db569b-06fc-4679-8a17-57fe2506d6d7 (TestCreateUser WaitUntilPolicyExistsWithContext)"),
+			merr: map[string]error{
+				"WaitUntilPolicyExistsWithContext": errors.New("TestCreateUser WaitUntilPolicyExistsWithContext"),
+			},
+		},
+		{
+			id: "3fad3da9-b485-4e19-a71d-77bb638964ed",
+			group: &testGroup{
+				group: &iam.Group{
+					GroupName: aws.String("dataset-3fad3da9-b485-4e19-a71d-77bb638964ed-DsTmpGrp"),
+				},
+			},
+			users: []*testUser{
+				{
+					user: &iam.User{
+						Arn:      aws.String("arn:aws:iam::12345678901:users/dataset-3fad3da9-b485-4e19-a71d-77bb638964ed-DsTmpUsr"),
+						UserName: aws.String("dataset-3fad3da9-b485-4e19-a71d-77bb638964ed-DsTmpUsr"),
+					},
+					accessKeys: []*iam.AccessKeyMetadata{},
+				},
+			},
+			err: errors.New("InternalError: create group for dataset 3fad3da9-b485-4e19-a71d-77bb638964ed (TestCreateUser CreateGroupWithContext)"),
+			merr: map[string]error{
+				"CreateGroupWithContext": errors.New("TestCreateUser CreateGroupWithContext"),
+			},
+		},
+		{
+			id: "8462a15d-5456-4ec2-98ee-c6a3a9a055e9",
+			group: &testGroup{
+				group: &iam.Group{
+					GroupName: aws.String("dataset-8462a15d-5456-4ec2-98ee-c6a3a9a055e9-DsTmpGrp"),
+				},
+			},
+			users: []*testUser{
+				{
+					user: &iam.User{
+						Arn:      aws.String("arn:aws:iam::12345678901:users/dataset-8462a15d-5456-4ec2-98ee-c6a3a9a055e9-DsTmpUsr"),
+						UserName: aws.String("dataset-8462a15d-5456-4ec2-98ee-c6a3a9a055e9-DsTmpUsr"),
+					},
+					accessKeys: []*iam.AccessKeyMetadata{},
+				},
+			},
+			err: errors.New("InternalError: attach policy to group for dataset 8462a15d-5456-4ec2-98ee-c6a3a9a055e9 (TestCreateUser AttachGroupPolicyWithContext)"),
+			merr: map[string]error{
+				"AttachGroupPolicyWithContext": errors.New("TestCreateUser AttachGroupPolicyWithContext"),
+			},
+		},
+		{
+			id: "5a1a1e09-a837-4b4e-84fd-0fb47d14b7fe",
+			group: &testGroup{
+				group: &iam.Group{
+					GroupName: aws.String("dataset-5a1a1e09-a837-4b4e-84fd-0fb47d14b7fe-DsTmpGrp"),
+				},
+			},
+			users: []*testUser{
+				{
+					user: &iam.User{
+						Arn:      aws.String("arn:aws:iam::12345678901:users/dataset-5a1a1e09-a837-4b4e-84fd-0fb47d14b7fe-DsTmpUsr"),
+						UserName: aws.String("dataset-5a1a1e09-a837-4b4e-84fd-0fb47d14b7fe-DsTmpUsr"),
+					},
+					accessKeys: []*iam.AccessKeyMetadata{},
+				},
+			},
+			err: errors.New("InternalError: create user for dataset 5a1a1e09-a837-4b4e-84fd-0fb47d14b7fe (TestCreateUser CreateUserWithContext)"),
+			merr: map[string]error{
+				"CreateUserWithContext": errors.New("TestCreateUser CreateUserWithContext"),
+			},
+		},
+		{
+			id: "8447af60-1174-49a0-bc06-3ea18755fa25",
+			group: &testGroup{
+				group: &iam.Group{
+					GroupName: aws.String("dataset-8447af60-1174-49a0-bc06-3ea18755fa25-DsTmpGrp"),
+				},
+			},
+			users: []*testUser{
+				{
+					user: &iam.User{
+						Arn:      aws.String("arn:aws:iam::12345678901:users/dataset-8447af60-1174-49a0-bc06-3ea18755fa25-DsTmpUsr"),
+						UserName: aws.String("dataset-8447af60-1174-49a0-bc06-3ea18755fa25-DsTmpUsr"),
+					},
+					accessKeys: []*iam.AccessKeyMetadata{},
+				},
+			},
+			err: errors.New("InternalError: waiting for user to exist for dataset 8447af60-1174-49a0-bc06-3ea18755fa25 (TestCreateUser WaitUntilUserExistsWithContext)"),
+			merr: map[string]error{
+				"WaitUntilUserExistsWithContext": errors.New("TestCreateUser WaitUntilUserExistsWithContext"),
+			},
+		},
+		{
+			id: "0d987a82-fa02-420b-8ea0-46d4d63a86a6",
+			group: &testGroup{
+				group: &iam.Group{
+					GroupName: aws.String("dataset-0d987a82-fa02-420b-8ea0-46d4d63a86a6-DsTmpGrp"),
+				},
+			},
+			users: []*testUser{
+				{
+					user: &iam.User{
+						Arn:      aws.String("arn:aws:iam::12345678901:users/dataset-0d987a82-fa02-420b-8ea0-46d4d63a86a6-DsTmpUsr"),
+						UserName: aws.String("dataset-0d987a82-fa02-420b-8ea0-46d4d63a86a6-DsTmpUsr"),
+					},
+					accessKeys: []*iam.AccessKeyMetadata{},
+				},
+			},
+			err: errors.New("InternalError: create user access key for dataset 0d987a82-fa02-420b-8ea0-46d4d63a86a6 (TestCreateUser CreateAccessKeyWithContext)"),
+			merr: map[string]error{
+				"CreateAccessKeyWithContext": errors.New("TestCreateUser CreateAccessKeyWithContext"),
+			},
+		},
+		{
+			id: "3830f909-bfd7-4bae-87bd-cf9f0aeeac20",
+			group: &testGroup{
+				group: &iam.Group{
+					GroupName: aws.String("dataset-3830f909-bfd7-4bae-87bd-cf9f0aeeac20-DsTmpGrp"),
+				},
+			},
+			users: []*testUser{
+				{
+					user: &iam.User{
+						Arn:      aws.String("arn:aws:iam::12345678901:users/dataset-3830f909-bfd7-4bae-87bd-cf9f0aeeac20-DsTmpUsr"),
+						UserName: aws.String("dataset-3830f909-bfd7-4bae-87bd-cf9f0aeeac20-DsTmpUsr"),
+					},
+					accessKeys: []*iam.AccessKeyMetadata{},
+				},
+			},
+			err: errors.New("InternalError: add user to group for dataset 3830f909-bfd7-4bae-87bd-cf9f0aeeac20 (TestCreateUser AddUserToGroupWithContext)"),
+			merr: map[string]error{
+				"AddUserToGroupWithContext": errors.New("TestCreateUser AddUserToGroupWithContext"),
+			},
+		},
+	}
+	testDatasets = append(newTestDatasets(), createUserErrTests...)
+
+	t.Logf("length of tests: %d", len(testDatasets))
+
+	for _, tds := range testDatasets {
+		s := newTestS3Repository(t)
+		if tds.merr != nil {
+			s.IAM.(*mockIAMClient).err = tds.merr
+			if _, err := s.CreateUser(context.TODO(), tds.id); err != nil {
+				if err.Error() != tds.err.Error() {
+					t.Errorf("expected error '%s', got '%s'", tds.err, err)
+				}
+			} else {
+				t.Error("expected error, got nil")
+			}
+			continue
+		}
+
+		t.Logf("testing with tds: %+v\n", tds)
+
+		expected := struct {
+			Group       string            `json:"group"`
+			Policy      string            `json:"policy"`
+			User        string            `json:"user"`
+			Credentials map[string]string `json:"credentials"`
+		}{
+			Group:  fmt.Sprintf("dataset-%s-DsTmpGrp", tds.id),
+			Policy: fmt.Sprintf("dataset-%s-DsTmpPlc", tds.id),
+			User:   fmt.Sprintf("dataset-%s-DsTmpUsr", tds.id),
+			Credentials: map[string]string{
+				"akid":   fmt.Sprintf("dataset-%s-DsTmpUsrKEY", tds.id),
+				"secret": fmt.Sprintf("dataset-%s-DsTmpUsrSECRET", tds.id),
+			},
+		}
+
+		out, err := s.CreateUser(context.TODO(), tds.id)
+		if err != nil && tds.err == nil {
+			t.Errorf("expected nil error, got %s", err)
+		} else if err == nil && tds.err != nil {
+			t.Errorf("expected err %s, got nil", tds.err)
+		} else if err != nil {
+			if tds.err.Error() != err.Error() {
+				t.Errorf("expected error %s, got %s", tds.err, err)
+			}
+		} else {
+			if !reflect.DeepEqual(expected, out) {
+				t.Errorf("expected %+v, got %+v", expected, out)
+			}
+		}
+	}
+}
+
+func TestDeleteUser(t *testing.T) {
+	deleteUserErrTests := []testDataset{
+		{
+			id:  "",
+			err: errors.New("BadRequest: invalid input (empty id)"),
+		},
+	}
+	testDatasets = append(newTestDatasets(), deleteUserErrTests...)
+
+	t.Logf("length of tests: %d", len(testDatasets))
+
+	for _, tds := range testDatasets {
+		s := newTestS3Repository(t)
+		if tds.merr != nil {
+			s.IAM.(*mockIAMClient).err = tds.merr
+			if err := s.DeleteUser(context.TODO(), tds.id); err != nil {
+				if err.Error() != tds.err.Error() {
+					t.Errorf("expected error '%s', got '%s'", tds.err, err)
+				}
+			} else {
+				t.Error("expected error, got nil")
+			}
+			continue
+		}
+
+		t.Logf("testing with tds: %+v\n", tds)
+
+		if err := s.DeleteUser(context.TODO(), tds.id); err != nil && tds.err == nil {
+			t.Errorf("expected nil error, got %s", err)
+		} else if err == nil && tds.err != nil {
+			t.Errorf("expected err %s, got nil", tds.err)
+		} else if err != nil {
+			if tds.err.Error() != err.Error() {
+				t.Errorf("expected error %s, got %s", tds.err, err)
+			}
+		}
+	}
+}
+
+func TestUpdateUser(t *testing.T) {
+	updateUserErrTests := []testDataset{
+		{
+			id:  "",
+			err: errors.New("BadRequest: invalid input (empty id)"),
+		},
+		{
+			id: "091faadd-b8b8-449c-a6ba-88f9c5020556",
+			group: &testGroup{
+				group: &iam.Group{
+					GroupName: aws.String("dataset-091faadd-b8b8-449c-a6ba-88f9c5020556-DsTmpGrp"),
+				},
+			},
+			users: []*testUser{
+				{
+					user: &iam.User{
+						Arn:      aws.String("arn:aws:iam::12345678901:users/dataset-091faadd-b8b8-449c-a6ba-88f9c5020556-DsTmpUsr"),
+						UserName: aws.String("dataset-091faadd-b8b8-449c-a6ba-88f9c5020556-DsTmpUsr"),
+					},
+					accessKeys: []*iam.AccessKeyMetadata{},
+				},
+			},
+			err: errors.New("InternalError: listing user access keys for dataset 091faadd-b8b8-449c-a6ba-88f9c5020556 (TestUpdateUser ListAccessKeysWithContext)"),
+			merr: map[string]error{
+				"ListAccessKeysWithContext": errors.New("TestUpdateUser ListAccessKeysWithContext"),
+			},
+		},
+		{
+			id: "9e0f9251-9672-40dc-85b0-05cc2e146f30",
+			group: &testGroup{
+				group: &iam.Group{
+					GroupName: aws.String("dataset-9e0f9251-9672-40dc-85b0-05cc2e146f30-DsTmpGrp"),
+				},
+			},
+			users: []*testUser{
+				{
+					user: &iam.User{
+						Arn:      aws.String("arn:aws:iam::12345678901:users/dataset-9e0f9251-9672-40dc-85b0-05cc2e146f30-DsTmpUsr"),
+						UserName: aws.String("dataset-9e0f9251-9672-40dc-85b0-05cc2e146f30-DsTmpUsr"),
+					},
+					accessKeys: []*iam.AccessKeyMetadata{},
+				},
+			},
+			err: errors.New("InternalError: create user access key for dataset 9e0f9251-9672-40dc-85b0-05cc2e146f30 (TestUpdateUser CreateAccessKeyWithContext)"),
+			merr: map[string]error{
+				"CreateAccessKeyWithContext": errors.New("TestUpdateUser CreateAccessKeyWithContext"),
+			},
+		},
+		{
+			id: "8b17eea2-2afe-4eaf-9c1f-efe0f210c387",
+			group: &testGroup{
+				group: &iam.Group{
+					GroupName: aws.String("dataset-8b17eea2-2afe-4eaf-9c1f-efe0f210c387-DsTmpGrp"),
+				},
+			},
+			users: []*testUser{
+				{
+					user: &iam.User{
+						Arn:      aws.String("arn:aws:iam::12345678901:users/dataset-8b17eea2-2afe-4eaf-9c1f-efe0f210c387-DsTmpUsr"),
+						UserName: aws.String("dataset-8b17eea2-2afe-4eaf-9c1f-efe0f210c387-DsTmpUsr"),
+					},
+					accessKeys: []*iam.AccessKeyMetadata{
+						{
+							AccessKeyId: aws.String("OPQRSTUV"),
+							Status:      aws.String("Active"),
+						},
+					},
+				},
+			},
+			err: errors.New("InternalError: deactivating user access key for dataset 8b17eea2-2afe-4eaf-9c1f-efe0f210c387 (TestUpdateUser UpdateAccessKeyWithContext)"),
+			merr: map[string]error{
+				"UpdateAccessKeyWithContext": errors.New("TestUpdateUser UpdateAccessKeyWithContext"),
+			},
+		},
+	}
+	testDatasets = append(newTestDatasets(), updateUserErrTests...)
+
+	t.Logf("length of tests: %d", len(testDatasets))
+
+	for _, tds := range testDatasets {
+		s := newTestS3Repository(t)
+		if tds.merr != nil {
+			s.IAM.(*mockIAMClient).err = tds.merr
+			if _, err := s.UpdateUser(context.TODO(), tds.id); err != nil {
+				if err.Error() != tds.err.Error() {
+					t.Errorf("expected error '%s', got '%s'", tds.err, err)
+				}
+			} else {
+				t.Error("expected error, got nil")
+			}
+			continue
+		}
+
+		var expected map[string]interface{}
+		for _, u := range tds.users {
+			keyid := aws.StringValue(u.user.UserName) + "KEY"
+			secret := aws.StringValue(u.user.UserName) + "SECRET"
+			keys := map[string]string{}
+			for _, k := range u.accessKeys {
+				keys[aws.StringValue(k.AccessKeyId)] = "Inactive"
+			}
+
+			if len(u.accessKeys) < 2 {
+				expected = map[string]interface{}{
+					"keys": keys,
+					"credentials": struct {
+						KeyId  string `json:"akid"`
+						Secret string `json:"secret"`
+					}{
+						KeyId:  keyid,
+						Secret: secret,
+					},
+				}
+			} else {
+				active := 0
+				for _, k := range u.accessKeys {
+					if aws.StringValue(k.Status) == "Active" {
+						active += 1
+					}
+				}
+
+				if active == 0 {
+					tds.err = errors.New("LimitExceeded: too many access keys (2)")
+				} else {
+					expected = map[string]interface{}{"keys": keys}
+				}
+
+			}
+		}
+
+		out, err := s.UpdateUser(context.TODO(), tds.id)
+		if err != nil && tds.err == nil {
+			t.Errorf("expected nil error, got %s", err)
+		} else if err == nil && tds.err != nil {
+			t.Errorf("expected err %s, got nil", tds.err)
+		} else if err != nil {
+			if tds.err.Error() != err.Error() {
+				t.Errorf("expected error %s, got %s", tds.err, err)
+			}
+		} else {
+			t.Logf("got output %+v", out)
+
+			if !reflect.DeepEqual(expected, out) {
+				t.Errorf("expected %+v, got %+v", expected, out)
+			}
+		}
+	}
+}


### PR DESCRIPTION
This PR adds endpoints for creating, listing and deleting users.  It also adds an endpoint to move authentication through the lifecycle for a temporary user.