### PR TITLE
Initial support for uploading and listing attachments

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,9 @@ POST /v1/ds/{account}/datasets
 GET /v1/ds/{account}/datasets/{id}
 DELETE /v1/ds/{account}/datasets/{id}
 
+POST /v1/ds/{account}/datasets/{id}/attachments
+GET /v1/ds/{account}/datasets/{id}/attachments
+
 GET /v1/ds/{account}/datasets/{id}/instances
 POST /v1/ds/{account}/datasets/{id}/instances
 DELETE /v1/ds/{account}/datasets/{id}/instances/{instance_id}
@@ -174,6 +177,60 @@ DELETE /v1/ds/{account}/datasets/{id}
 | **204 OK**                    | okay                                 |
 | **400 Bad Request**           | badly formed request                 |
 | **404 Not Found**             | dataset not found                    |
+| **500 Internal Server Error** | a server error occurred              |
+
+
+### Create attachment for a dataset
+
+POST /v1/ds/{account}/datasets/{id}/attachments
+
+The request needs to be a `multipart/form-data` with the following parameters:
+  - `name` - the name of the attachment as it should be saved, e.g. `eula.txt`
+  - `attachment` - the content of the file being uploaded
+
+#### Response
+
+```json
+[
+    "eula.txt"
+]
+```
+
+| Response Code                 | Definition                           |
+| ----------------------------- | -------------------------------------|
+| **200 OK**                    | okay                                 |
+| **400 Bad Request**           | badly formed request, or file too big|
+| **404 Not Found**             | dataset not found                    |
+| **500 Internal Server Error** | a server error occurred              |
+
+### Get attachments for a dataset
+
+GET /v1/ds/{account}/datasets/{id}/attachments
+
+#### Response
+
+```json
+[
+    {
+        "Name": "Dataset Data Use Agreement.pdf",
+        "Modified": "2020-05-17T02:04:27Z",
+        "Size": 3708454,
+        "URL": "https://dataset-localdev-3cadbe31-27e9-4f7a-9515-51ec9d754022.s3.amazonaws.com/_attachments/Dataset%20Data%20Use%20Agreement.pdf?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAXQVXYEBXA5X5LRN3%2F20200518%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20200518T132423Z&X-Amz-Expires=300&X-Amz-SignedHeaders=host&X-Amz-Signature=342d937b7b726408c2efe41493d126ea577204f85ffe77ffc9b3cf22af80c7ea"
+    },
+    {
+        "Name": "eula.txt",
+        "Modified": "2020-05-18T13:19:34Z",
+        "Size": 6920,
+        "URL": "https://dataset-localdev-3cadbe31-27e9-4f7a-9515-51ec9d754022.s3.amazonaws.com/_attachments/eula.txt?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAXQVXYEBXA5X5LRN3%2F20200518%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20200518T132423Z&X-Amz-Expires=300&X-Amz-SignedHeaders=host&X-Amz-Signature=c2d7f7165ce3c099e8eefcb14e3b4c7e0e6a319af48d6727f25519f35488b14a"
+    }
+]
+```
+
+| Response Code                 | Definition                           |
+| ----------------------------- | -------------------------------------|
+| **200 OK**                    | okay                                 |
+| **400 Bad Request**           | badly formed request                 |
+| **404 Not Found**             | account/dataset not found            |
 | **500 Internal Server Error** | a server error occurred              |
 
 

--- a/api/handlers_attachments.go
+++ b/api/handlers_attachments.go
@@ -131,7 +131,7 @@ func (s *server) AttachmentListHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// list attachments for this data repository
-	datasetAttachments, err := attachmentRepo.ListAttachments(r.Context(), id)
+	datasetAttachments, err := attachmentRepo.ListAttachments(r.Context(), id, true)
 	if err != nil {
 		msg := fmt.Sprintf("failed to list attachments for dataset %s: %s", id, err)
 		handleError(w, apierror.New(apierror.ErrInternalError, msg, err))

--- a/api/handlers_attachments.go
+++ b/api/handlers_attachments.go
@@ -42,6 +42,7 @@ func (s *server) AttachmentCreateHandler(w http.ResponseWriter, r *http.Request)
 
 	// limit total request size to 50 MB
 	r.Body = http.MaxBytesReader(w, r.Body, 50<<20)
+	defer r.Body.Close()
 
 	// parse the multipart form and keep up to 32 MB in memory (the rest on temp disk)
 	err = r.ParseMultipartForm(32 << 20)
@@ -70,7 +71,8 @@ func (s *server) AttachmentCreateHandler(w http.ResponseWriter, r *http.Request)
 	log.Debugf("attachment size (bytes): %v", attachmentHeader.Size)
 
 	if attachmentHeader.Size > maxAttachmentSize {
-		handleError(w, apierror.New(apierror.ErrBadRequest, "attachment size too big", err))
+		msg := fmt.Sprintf("attachment size too big (max limit is %d bytes)", maxAttachmentSize)
+		handleError(w, apierror.New(apierror.ErrBadRequest, msg, err))
 		return
 	}
 

--- a/api/handlers_attachments.go
+++ b/api/handlers_attachments.go
@@ -50,8 +50,6 @@ func (s *server) AttachmentCreateHandler(w http.ResponseWriter, r *http.Request)
 		return
 	}
 
-	log.Debug(r.MultipartForm)
-
 	// get the attachment name
 	attachmentName := r.FormValue("name")
 	if attachmentName == "" {
@@ -75,8 +73,6 @@ func (s *server) AttachmentCreateHandler(w http.ResponseWriter, r *http.Request)
 		handleError(w, apierror.New(apierror.ErrBadRequest, "attachment size too big", err))
 		return
 	}
-
-	log.Infof("creating attachment for data set '%s' in account '%s': %s", id, account, attachmentName)
 
 	err = attachmentRepo.CreateAttachment(r.Context(), id, attachmentName, attachment)
 	if err != nil {
@@ -114,8 +110,6 @@ func (s *server) AttachmentListHandler(w http.ResponseWriter, r *http.Request) {
 		handleError(w, apierror.New(apierror.ErrNotFound, msg, nil))
 		return
 	}
-
-	log.Debugf("listing attachments for data set '%s' in account %s", id, account)
 
 	metadata, err := service.MetadataRepository.Get(r.Context(), account, id)
 	if err != nil {

--- a/api/handlers_attachments.go
+++ b/api/handlers_attachments.go
@@ -1,0 +1,156 @@
+package api
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+
+	"github.com/YaleSpinup/ds-api/apierror"
+	"github.com/gorilla/mux"
+	log "github.com/sirupsen/logrus"
+)
+
+// limit individual attachment files to 32 MB
+const maxAttachmentSize = 32 * 1024 * 1024
+
+// AttachmentCreateHandler adds an attachment file to a dataset
+func (s *server) AttachmentCreateHandler(w http.ResponseWriter, r *http.Request) {
+	w = LogWriter{w}
+	vars := mux.Vars(r)
+	account := vars["account"]
+	id := vars["id"]
+
+	service, ok := s.datasetServices[account]
+	if !ok {
+		msg := fmt.Sprintf("account not found: %s", account)
+		handleError(w, apierror.New(apierror.ErrNotFound, msg, nil))
+		return
+	}
+
+	metadata, err := service.MetadataRepository.Get(r.Context(), account, id)
+	if err != nil {
+		handleError(w, err)
+		return
+	}
+
+	attachmentRepo, ok := service.AttachmentRepository[metadata.DataStorage]
+	if !ok {
+		msg := fmt.Sprintf("requested attachment repository type not supported for this account: %s", metadata.DataStorage)
+		handleError(w, apierror.New(apierror.ErrBadRequest, msg, nil))
+		return
+	}
+
+	// limit total request size to 50 MB
+	r.Body = http.MaxBytesReader(w, r.Body, 50<<20)
+
+	// parse the multipart form and keep up to 32 MB in memory (the rest on temp disk)
+	err = r.ParseMultipartForm(32 << 20)
+	if err != nil {
+		handleError(w, apierror.New(apierror.ErrBadRequest, "failed to parse multipart request", err))
+		return
+	}
+
+	log.Debug(r.MultipartForm)
+
+	// get the attachment name
+	attachmentName := r.FormValue("name")
+	if attachmentName == "" {
+		handleError(w, apierror.New(apierror.ErrBadRequest, "failed to parse form value: name", err))
+		return
+	}
+
+	log.Debugf("attachment name: %s", attachmentName)
+
+	// get the (first) attachment file
+	attachment, attachmentHeader, err := r.FormFile("attachment")
+	if err != nil {
+		handleError(w, apierror.New(apierror.ErrBadRequest, "failed to parse attachment", err))
+		return
+	}
+	defer attachment.Close()
+
+	log.Debugf("attachment size (bytes): %v", attachmentHeader.Size)
+
+	if attachmentHeader.Size > maxAttachmentSize {
+		handleError(w, apierror.New(apierror.ErrBadRequest, "attachment size too big", err))
+		return
+	}
+
+	log.Infof("creating attachment for data set '%s' in account '%s': %s", id, account, attachmentName)
+
+	err = attachmentRepo.CreateAttachment(r.Context(), id, attachmentName, attachment)
+	if err != nil {
+		msg := fmt.Sprintf("failed to create attachment for dataset %s: %s", id, err)
+		handleError(w, apierror.New(apierror.ErrInternalError, msg, err))
+		return
+	}
+
+	output := []string{
+		attachmentName,
+	}
+
+	j, err := json.Marshal(&output)
+	if err != nil {
+		msg := fmt.Sprintf("cannot encode dataset attachment output into json: %s", err)
+		handleError(w, apierror.New(apierror.ErrBadRequest, msg, err))
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	w.Write(j)
+}
+
+// AttachmentListHandler lists all attachments for a dataset
+func (s *server) AttachmentListHandler(w http.ResponseWriter, r *http.Request) {
+	w = LogWriter{w}
+	vars := mux.Vars(r)
+	account := vars["account"]
+	id := vars["id"]
+
+	service, ok := s.datasetServices[account]
+	if !ok {
+		msg := fmt.Sprintf("account not found: %s", account)
+		handleError(w, apierror.New(apierror.ErrNotFound, msg, nil))
+		return
+	}
+
+	log.Debugf("listing attachments for data set '%s' in account %s", id, account)
+
+	metadata, err := service.MetadataRepository.Get(r.Context(), account, id)
+	if err != nil {
+		handleError(w, err)
+		return
+	}
+
+	attachmentRepo, ok := service.AttachmentRepository[metadata.DataStorage]
+	if !ok {
+		msg := fmt.Sprintf("requested attachment repository type not supported for this account: %s", metadata.DataStorage)
+		handleError(w, apierror.New(apierror.ErrBadRequest, msg, nil))
+		return
+	}
+
+	// list attachments for this data repository
+	datasetAttachments, err := attachmentRepo.ListAttachments(r.Context(), id)
+	if err != nil {
+		msg := fmt.Sprintf("failed to list attachments for dataset %s: %s", id, err)
+		handleError(w, apierror.New(apierror.ErrInternalError, msg, err))
+		return
+	}
+
+	j, err := json.Marshal(&datasetAttachments)
+	if err != nil {
+		msg := fmt.Sprintf("cannot encode dataset attachments output into json: %s", err)
+		handleError(w, apierror.New(apierror.ErrBadRequest, msg, err))
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	w.Write(j)
+}
+
+// AttachmentDeleteHandler removes an attachment file from a dataset
+func (s *server) AttachmentDeleteHandler(w http.ResponseWriter, r *http.Request) {
+	// TODO
+}

--- a/api/routes.go
+++ b/api/routes.go
@@ -18,6 +18,10 @@ func (s *server) routes() {
 	api.HandleFunc("/{account}/datasets/{id}", s.DatasetUpdateHandler).Methods(http.MethodPut)
 	api.HandleFunc("/{account}/datasets/{id}", s.DatasetDeleteHandler).Methods(http.MethodDelete)
 
+	api.HandleFunc("/{account}/datasets/{id}/attachments", s.AttachmentListHandler).Methods(http.MethodGet)
+	api.HandleFunc("/{account}/datasets/{id}/attachments", s.AttachmentCreateHandler).Methods(http.MethodPost)
+	api.HandleFunc("/{account}/datasets/{id}/attachments", s.AttachmentDeleteHandler).Methods(http.MethodDelete)
+
 	api.HandleFunc("/{account}/datasets/{id}/instances", s.InstanceListHandler).Methods(http.MethodGet)
 	api.HandleFunc("/{account}/datasets/{id}/instances", s.InstanceCreateHandler).Methods(http.MethodPost)
 	api.HandleFunc("/{account}/datasets/{id}/instances/{instance_id}", s.InstanceDeleteHandler).Methods(http.MethodDelete)

--- a/dataset/dataset.go
+++ b/dataset/dataset.go
@@ -2,14 +2,17 @@ package dataset
 
 import (
 	"context"
+	"mime/multipart"
+	"time"
 
 	"github.com/google/uuid"
 )
 
-// Service is a collection of one or more Data Repositories and a Matadata Repository for storing datasets
+// Service is a collection of one or more Data/Attachment Repositories and a Matadata Repository for storing datasets
 type Service struct {
-	MetadataRepository MetadataRepository
-	DataRepository     map[string]DataRepository
+	MetadataRepository   MetadataRepository
+	DataRepository       map[string]DataRepository
+	AttachmentRepository map[string]AttachmentRepository
 }
 
 // MetadataRepository is an interface for metadata repository
@@ -35,8 +38,22 @@ type DataRepository interface {
 	UpdateUser(ctx context.Context, id string) (map[string]interface{}, error)
 }
 
+// AttachmentRepository is an interface for attachment repository
+type AttachmentRepository interface {
+	CreateAttachment(ctx context.Context, id, attachmentName string, attachmentBody multipart.File) error
+	ListAttachments(ctx context.Context, id string) ([]Attachment, error)
+}
+
 // Access contains necessary information in order to access a dataset
 type Access map[string]string
+
+// Attachment contains information about a dataset attachment
+type Attachment struct {
+	Name     string
+	Modified time.Time
+	Size     int64
+	URL      string
+}
 
 // ServiceOption is a function to set service options
 type ServiceOption func(*Service)
@@ -63,6 +80,13 @@ func WithMetadataRepository(repo MetadataRepository) ServiceOption {
 func WithDataRepository(repos map[string]DataRepository) ServiceOption {
 	return func(s *Service) {
 		s.DataRepository = repos
+	}
+}
+
+// WithAttachmentRepository sets the AttachmentRepository list for the service
+func WithAttachmentRepository(repos map[string]AttachmentRepository) ServiceOption {
+	return func(s *Service) {
+		s.AttachmentRepository = repos
 	}
 }
 

--- a/dataset/dataset.go
+++ b/dataset/dataset.go
@@ -41,7 +41,7 @@ type DataRepository interface {
 // AttachmentRepository is an interface for attachment repository
 type AttachmentRepository interface {
 	CreateAttachment(ctx context.Context, id, attachmentName string, attachmentBody multipart.File) error
-	ListAttachments(ctx context.Context, id string) ([]Attachment, error)
+	ListAttachments(ctx context.Context, id string, showURL bool) ([]Attachment, error)
 }
 
 // Access contains necessary information in order to access a dataset
@@ -52,7 +52,7 @@ type Attachment struct {
 	Name     string
 	Modified time.Time
 	Size     int64
-	URL      string
+	URL      string `json:",omitempty"`
 }
 
 // ServiceOption is a function to set service options

--- a/go.mod
+++ b/go.mod
@@ -9,5 +9,6 @@ require (
 	github.com/gorilla/mux v1.7.4
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.5.0
+	github.com/prometheus/common v0.9.1
 	github.com/sirupsen/logrus v1.4.2
 )

--- a/go.sum
+++ b/go.sum
@@ -1,6 +1,8 @@
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
+github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751 h1:JYp7IbQjafoB+tBA3gMyHYHrpOtNuDiK/uB5uXxq5wM=
 github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
+github.com/alecthomas/units v0.0.0-20190717042225-c3de453c63f4 h1:Hs82Z41s6SdL1CELW+XaDYmOH4hkBN4/N9og/AsOv7E=
 github.com/alecthomas/units v0.0.0-20190717042225-c3de453c63f4/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
 github.com/aws/aws-sdk-go v1.29.17 h1:ygbf7/bKjFMTtyY1ERINUZX21kevbl8XzDI8jyxz93g=
 github.com/aws/aws-sdk-go v1.29.17/go.mod h1:1KvfttTE3SPKMpo8g2c6jL3ZKfXtFvKscTgahTma5Xg=
@@ -103,6 +105,7 @@ golang.org/x/text v0.3.0 h1:g61tztE5qeGQ89tm6NTjjM9VPIm088od1l6aSorWRWg=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 h1:E7g+9GITq07hpfrRu66IVDexMakfv52eLZ2CXBWiKr4=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
+gopkg.in/alecthomas/kingpin.v2 v2.2.6 h1:jMFz6MfLP0/4fUyZle81rXUoxOBFi19VUFKVDOQfozc=
 gopkg.in/alecthomas/kingpin.v2 v2.2.6/go.mod h1:FMv+mEhP44yOT+4EoQTLFTRgOQ1FBLkstjWtayDeSgw=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 h1:YR8cESwS4TdDjEe65xsg0ogRM/Nc3DYOhEAlW+xobZo=

--- a/s3datarepository/attachments.go
+++ b/s3datarepository/attachments.go
@@ -19,6 +19,8 @@ const attachmentsPrefix = "_attachments/"
 
 // CreateAttachment uploads a new attachment to the data repository
 func (s *S3Repository) CreateAttachment(ctx context.Context, id, attachmentName string, attachmentBody multipart.File) error {
+	log.Infof("creating attachment for data set '%s': %s", id, attachmentName)
+
 	if id == "" {
 		return apierror.New(apierror.ErrBadRequest, "invalid input", errors.New("empty id"))
 	}
@@ -34,7 +36,7 @@ func (s *S3Repository) CreateAttachment(ctx context.Context, id, attachmentName 
 
 	attachmentName = attachmentsPrefix + attachmentName
 
-	log.Debugf("uploading attachment '%s' to s3datarepository: %s", attachmentName, name)
+	log.Infof("uploading attachment '%s' to s3datarepository: %s", attachmentName, name)
 
 	if _, err := s.S3Uploader.UploadWithContext(ctx, &s3manager.UploadInput{
 		Bucket: aws.String(name),

--- a/s3datarepository/attachments.go
+++ b/s3datarepository/attachments.go
@@ -1,0 +1,115 @@
+package s3datarepository
+
+import (
+	"context"
+	"errors"
+	"mime/multipart"
+	"strings"
+	"time"
+
+	"github.com/YaleSpinup/ds-api/apierror"
+	"github.com/YaleSpinup/ds-api/dataset"
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/s3"
+	"github.com/aws/aws-sdk-go/service/s3/s3manager"
+	log "github.com/sirupsen/logrus"
+)
+
+const attachmentsPrefix = "_attachments/"
+
+// CreateAttachment uploads a new attachment to the data repository
+func (s *S3Repository) CreateAttachment(ctx context.Context, id, attachmentName string, attachmentBody multipart.File) error {
+	if id == "" {
+		return apierror.New(apierror.ErrBadRequest, "invalid input", errors.New("empty id"))
+	}
+
+	if attachmentName == "" {
+		return apierror.New(apierror.ErrBadRequest, "invalid input", errors.New("empty attachment name"))
+	}
+
+	name := id
+	if s.NamePrefix != "" {
+		name = s.NamePrefix + "-" + name
+	}
+
+	attachmentName = attachmentsPrefix + attachmentName
+
+	log.Debugf("uploading attachment '%s' to s3datarepository: %s", attachmentName, name)
+
+	if _, err := s.S3Uploader.UploadWithContext(ctx, &s3manager.UploadInput{
+		Bucket: aws.String(name),
+		Key:    aws.String(attachmentName),
+		Body:   attachmentBody,
+	}); err != nil {
+		return ErrCode("failed to upload attachment to s3 bucket "+name, err)
+	}
+
+	return nil
+}
+
+// ListAttachments lists all attachments for the data repository
+func (s *S3Repository) ListAttachments(ctx context.Context, id string) ([]dataset.Attachment, error) {
+	if id == "" {
+		return nil, apierror.New(apierror.ErrBadRequest, "invalid input", errors.New("empty id"))
+	}
+
+	name := id
+	if s.NamePrefix != "" {
+		name = s.NamePrefix + "-" + name
+	}
+
+	log.Debugf("getting list of attachments for s3datarepository: %s", name)
+
+	return s.listAttachmentObjects(ctx, name, attachmentsPrefix)
+}
+
+// listAttachmentObjects lists all objects under the given prefix, and generates a pre-signed URL for each one
+func (s *S3Repository) listAttachmentObjects(ctx context.Context, bucket, prefix string) ([]dataset.Attachment, error) {
+	objs := []dataset.Attachment{}
+
+	input := s3.ListObjectsV2Input{
+		Bucket: aws.String(bucket),
+		Prefix: aws.String(prefix),
+	}
+
+	truncated := true
+	for truncated {
+		output, err := s.S3.ListObjectsV2WithContext(ctx, &input)
+		if err != nil {
+			return nil, ErrCode("failed to list objects from s3 ", err)
+		}
+
+		for _, object := range output.Contents {
+			id := strings.TrimPrefix(aws.StringValue(object.Key), prefix)
+			if id != "" {
+				// generate pre-signed URL for accessing the attachment
+				urlStr, err := s.presignURL(bucket, aws.StringValue(object.Key))
+				if err != nil {
+					log.Errorf("failed to presign request for %s: %s", aws.StringValue(object.Key), err)
+				}
+
+				objs = append(objs, dataset.Attachment{
+					Name:     strings.TrimPrefix(id, "/"),
+					Modified: aws.TimeValue(object.LastModified),
+					Size:     aws.Int64Value(object.Size),
+					URL:      urlStr,
+				})
+			}
+		}
+
+		truncated = aws.BoolValue(output.IsTruncated)
+		input.ContinuationToken = output.NextContinuationToken
+	}
+
+	log.Debug(objs)
+
+	return objs, nil
+}
+
+func (s *S3Repository) presignURL(bucket, key string) (string, error) {
+	req, _ := s.S3.GetObjectRequest(&s3.GetObjectInput{
+		Bucket: aws.String(bucket),
+		Key:    aws.String(key),
+	})
+	return req.Presign(5 * time.Minute)
+}

--- a/s3datarepository/attachments_test.go
+++ b/s3datarepository/attachments_test.go
@@ -1,0 +1,170 @@
+package s3datarepository
+
+import (
+	"context"
+	"fmt"
+	"mime/multipart"
+	"reflect"
+	"testing"
+
+	"github.com/YaleSpinup/ds-api/apierror"
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/aws/aws-sdk-go/aws/request"
+	"github.com/aws/aws-sdk-go/service/s3"
+	"github.com/aws/aws-sdk-go/service/s3/s3manager"
+	"github.com/aws/aws-sdk-go/service/s3/s3manager/s3manageriface"
+)
+
+// mockS3Uploader is a fake S3 Uploader
+type mockS3Uploader struct {
+	s3manageriface.UploaderAPI
+	t   *testing.T
+	err map[string]error
+}
+
+func newMockS3Uploader(t *testing.T) *mockS3Uploader {
+	return &mockS3Uploader{
+		t:   t,
+		err: make(map[string]error),
+	}
+}
+
+func (u mockS3Uploader) UploadWithContext(ctx aws.Context, input *s3manager.UploadInput, opts ...func(*s3manager.Uploader)) (*s3manager.UploadOutput, error) {
+	if err, ok := u.err["UploadWithContext"]; ok {
+		return nil, err
+	}
+	return &s3manager.UploadOutput{}, nil
+}
+
+// func (m *mockS3Client) GetObjectRequest(input *s3.GetObjectInput) (req *request.Request, output *s3.GetObjectOutput) {
+// 	return &request.Request{}, &s3.GetObjectOutput{}
+// }
+
+func (m *mockS3Client) ListObjectsV2WithContext(ctx aws.Context, input *s3.ListObjectsV2Input, opts ...request.Option) (*s3.ListObjectsV2Output, error) {
+	if err, ok := m.err["ListObjectsV2WithContext"]; ok {
+		return nil, err
+	}
+
+	if aws.StringValue(input.Prefix) == "_attachments/" {
+		contents := []*s3.Object{
+			&s3.Object{
+				Key:  aws.String(aws.StringValue(input.Prefix) + "test1.doc"),
+				Size: aws.Int64(10000),
+			},
+			&s3.Object{
+				Key:  aws.String(aws.StringValue(input.Prefix) + "test2.doc"),
+				Size: aws.Int64(20000),
+			},
+		}
+		return &s3.ListObjectsV2Output{Contents: contents}, nil
+	}
+
+	return nil, awserr.New(s3.ErrCodeNoSuchKey, aws.StringValue(input.Prefix)+" not found", nil)
+}
+
+func TestCreateAttachment(t *testing.T) {
+	var testAttachment multipart.File
+
+	// test success
+	s := S3Repository{S3Uploader: newMockS3Uploader(t)}
+	err := s.CreateAttachment(context.TODO(), "9C7BFAC0-0070-4FC2-8849-2F94A64B6FF8", "TestAttachment.txt", testAttachment)
+	if err != nil {
+		t.Errorf("expected nil error, got: %s", err)
+	}
+
+	// test empty id
+	s = S3Repository{S3Uploader: newMockS3Uploader(t)}
+	expectedCode := apierror.ErrBadRequest
+	expectedMessage := "invalid input"
+
+	err = s.CreateAttachment(context.TODO(), "", "TestAttachment.txt", testAttachment)
+	if err == nil {
+		t.Error("expected error, got: nil")
+	} else {
+		if aerr, ok := err.(apierror.Error); ok {
+			if aerr.Code != expectedCode {
+				t.Errorf("expected error code %s, got: %s", expectedCode, aerr.Code)
+			}
+			if aerr.Message != expectedMessage {
+				t.Errorf("expected error message '%s', got: '%s'", expectedMessage, aerr.Message)
+			}
+		} else {
+			t.Errorf("expected apierror.Error, got: %s", reflect.TypeOf(err).String())
+		}
+	}
+
+	// test empty name
+	s = S3Repository{S3Uploader: newMockS3Uploader(t)}
+	expectedCode = apierror.ErrBadRequest
+	expectedMessage = "invalid input"
+
+	err = s.CreateAttachment(context.TODO(), "9C7BFAC0-0070-4FC2-8849-2F94A64B6FF8", "", testAttachment)
+	if err == nil {
+		t.Error("expected error, got: nil")
+	} else {
+		if aerr, ok := err.(apierror.Error); ok {
+			if aerr.Code != expectedCode {
+				t.Errorf("expected error code %s, got: %s", expectedCode, aerr.Code)
+			}
+			if aerr.Message != expectedMessage {
+				t.Errorf("expected error message '%s', got: '%s'", expectedMessage, aerr.Message)
+			}
+		} else {
+			t.Errorf("expected apierror.Error, got: %s", reflect.TypeOf(err).String())
+		}
+	}
+
+	// test s3 upload failure
+	s = S3Repository{NamePrefix: "dataset", S3Uploader: newMockS3Uploader(t)}
+	expectedCode = apierror.ErrServiceUnavailable
+	expectedMessage = fmt.Sprintf("failed to upload attachment to s3 bucket dataset-9C7BFAC0-0070-4FC2-8849-2F94A64B6FF8")
+	s.S3Uploader.(*mockS3Uploader).err["UploadWithContext"] = awserr.New("InternalError", "Internal Error", nil)
+
+	err = s.CreateAttachment(context.TODO(), "9C7BFAC0-0070-4FC2-8849-2F94A64B6FF8", "TestAttachment.txt", testAttachment)
+	if err == nil {
+		t.Error("expected error, got: nil")
+	} else {
+		if aerr, ok := err.(apierror.Error); ok {
+			if aerr.Code != expectedCode {
+				t.Errorf("expected error code %s, got: %s", expectedCode, aerr.Code)
+			}
+			if aerr.Message != expectedMessage {
+				t.Errorf("expected error message '%s', got: '%s'", expectedMessage, aerr.Message)
+			}
+		} else {
+			t.Errorf("expected apierror.Error, got: %s", reflect.TypeOf(err).String())
+		}
+	}
+}
+
+func TestListAttachments(t *testing.T) {
+	s := S3Repository{NamePrefix: "dataset", S3: newMockS3Client(t)}
+
+	// test success
+	// _, err := s.ListAttachments(context.TODO(), "9C7BFAC0-0070-4FC2-8849-2F94A64B6FF8")
+	// if err != nil {
+	// 	t.Errorf("expected nil error, got: %s", err)
+	// }
+
+	// test empty id
+	s = S3Repository{NamePrefix: "dataset", S3: newMockS3Client(t)}
+	expectedCode := apierror.ErrBadRequest
+	expectedMessage := "invalid input"
+
+	_, err := s.ListAttachments(context.TODO(), "")
+	if err == nil {
+		t.Error("expected error, got: nil")
+	} else {
+		if aerr, ok := err.(apierror.Error); ok {
+			if aerr.Code != expectedCode {
+				t.Errorf("expected error code %s, got: %s", expectedCode, aerr.Code)
+			}
+			if aerr.Message != expectedMessage {
+				t.Errorf("expected error message '%s', got: '%s'", expectedMessage, aerr.Message)
+			}
+		} else {
+			t.Errorf("expected apierror.Error, got: %s", reflect.TypeOf(err).String())
+		}
+	}
+}

--- a/s3datarepository/errors_test.go
+++ b/s3datarepository/errors_test.go
@@ -1,0 +1,149 @@
+package s3datarepository
+
+import (
+	"testing"
+
+	"github.com/YaleSpinup/ds-api/apierror"
+	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/aws/aws-sdk-go/service/iam"
+	"github.com/aws/aws-sdk-go/service/s3"
+	"github.com/pkg/errors"
+)
+
+func TestErrCode(t *testing.T) {
+	apiErrorTestCases := map[string]string{
+		"": apierror.ErrBadRequest,
+
+		"AccessDenied":       apierror.ErrForbidden,
+		"AccountProblem":     apierror.ErrForbidden,
+		"AllAccessDisabled":  apierror.ErrForbidden,
+		"Forbidden":          apierror.ErrForbidden,
+		"InvalidAccessKeyId": apierror.ErrForbidden,
+
+		iam.ErrCodeConcurrentModificationException: apierror.ErrConflict,
+		iam.ErrCodeDeleteConflictException:         apierror.ErrConflict,
+		iam.ErrCodeDuplicateCertificateException:   apierror.ErrConflict,
+		iam.ErrCodeDuplicateSSHPublicKeyException:  apierror.ErrConflict,
+		iam.ErrCodeEntityAlreadyExistsException:    apierror.ErrConflict,
+		s3.ErrCodeBucketAlreadyExists:              apierror.ErrConflict,
+		s3.ErrCodeBucketAlreadyOwnedByYou:          apierror.ErrConflict,
+		"BucketNotEmpty":                           apierror.ErrConflict,
+		"InvalidBucketState":                       apierror.ErrConflict,
+		"OperationAborted":                         apierror.ErrConflict,
+		"RestoreAlreadyInProgress":                 apierror.ErrConflict,
+
+		iam.ErrCodeNoSuchEntityException: apierror.ErrNotFound,
+		s3.ErrCodeNoSuchBucket:           apierror.ErrNotFound,
+		s3.ErrCodeNoSuchKey:              apierror.ErrNotFound,
+		s3.ErrCodeNoSuchUpload:           apierror.ErrNotFound,
+		"NotFound":                       apierror.ErrNotFound,
+		"NoSuchBucketPolicy":             apierror.ErrNotFound,
+		"NoSuchLifecycleConfiguration":   apierror.ErrNotFound,
+		"NoSuchVersion":                  apierror.ErrNotFound,
+
+		iam.ErrCodeCredentialReportExpiredException:       apierror.ErrBadRequest,
+		iam.ErrCodeCredentialReportNotPresentException:    apierror.ErrBadRequest,
+		iam.ErrCodeCredentialReportNotReadyException:      apierror.ErrBadRequest,
+		iam.ErrCodeEntityTemporarilyUnmodifiableException: apierror.ErrBadRequest,
+		iam.ErrCodeInvalidAuthenticationCodeException:     apierror.ErrBadRequest,
+		iam.ErrCodeInvalidCertificateException:            apierror.ErrBadRequest,
+		iam.ErrCodeInvalidInputException:                  apierror.ErrBadRequest,
+		iam.ErrCodeInvalidPublicKeyException:              apierror.ErrBadRequest,
+		iam.ErrCodeInvalidUserTypeException:               apierror.ErrBadRequest,
+		iam.ErrCodeKeyPairMismatchException:               apierror.ErrBadRequest,
+		iam.ErrCodeMalformedCertificateException:          apierror.ErrBadRequest,
+		iam.ErrCodeMalformedPolicyDocumentException:       apierror.ErrBadRequest,
+		iam.ErrCodePasswordPolicyViolationException:       apierror.ErrBadRequest,
+		iam.ErrCodePolicyEvaluationException:              apierror.ErrBadRequest,
+		iam.ErrCodePolicyNotAttachableException:           apierror.ErrBadRequest,
+		iam.ErrCodeUnrecognizedPublicKeyEncodingException: apierror.ErrBadRequest,
+		s3.ErrCodeObjectAlreadyInActiveTierError:          apierror.ErrBadRequest,
+		s3.ErrCodeObjectNotInActiveTierError:              apierror.ErrBadRequest,
+		"AmbiguousGrantByEmailAddress":                    apierror.ErrBadRequest,
+		"AuthorizationHeaderMalformed":                    apierror.ErrBadRequest,
+		"BadDigest":                                       apierror.ErrBadRequest,
+		"CredentialsNotSupported":                         apierror.ErrBadRequest,
+		"CrossLocationLoggingProhibited":                  apierror.ErrBadRequest,
+		"EntityTooSmall":                                  apierror.ErrBadRequest,
+		"EntityTooLarge":                                  apierror.ErrBadRequest,
+		"ExpiredToken":                                    apierror.ErrBadRequest,
+		"IllegalVersioningConfigurationException":         apierror.ErrBadRequest,
+		"IncompleteBody":                                  apierror.ErrBadRequest,
+		"IncorrectNumberOfFilesInPostRequest":             apierror.ErrBadRequest,
+		"InlineDataTooLarge":                              apierror.ErrBadRequest,
+		"InvalidAddressingHeader":                         apierror.ErrBadRequest,
+		"InvalidArgument":                                 apierror.ErrBadRequest,
+		"InvalidBucketName":                               apierror.ErrBadRequest,
+		"InvalidDigest":                                   apierror.ErrBadRequest,
+		"InvalidEncryptionAlgorithmError":                 apierror.ErrBadRequest,
+		"InvalidObjectState":                              apierror.ErrBadRequest,
+		"InvalidLocationConstraint":                       apierror.ErrBadRequest,
+		"InvalidPart":                                     apierror.ErrBadRequest,
+		"InvalidPartOrder":                                apierror.ErrBadRequest,
+		"InvalidPolicyDocument":                           apierror.ErrBadRequest,
+		"InvalidRange":                                    apierror.ErrBadRequest,
+		"InvalidRequest":                                  apierror.ErrBadRequest,
+		"InvalidSOAPRequest":                              apierror.ErrBadRequest,
+		"InvalidStorageClass":                             apierror.ErrBadRequest,
+		"InvalidTargetBucketForLogging":                   apierror.ErrBadRequest,
+		"InvalidToken":                                    apierror.ErrBadRequest,
+		"InvalidURI":                                      apierror.ErrBadRequest,
+		"KeyTooLongError":                                 apierror.ErrBadRequest,
+		"MalformedACLError":                               apierror.ErrBadRequest,
+		"MalformedPOSTRequest":                            apierror.ErrBadRequest,
+		"MalformedXML":                                    apierror.ErrBadRequest,
+		"MethodNotAllowed":                                apierror.ErrBadRequest,
+		"MissingAttachment":                               apierror.ErrBadRequest,
+		"MissingContentLength":                            apierror.ErrBadRequest,
+		"MissingRequestBodyError":                         apierror.ErrBadRequest,
+		"MissingSecurityElement":                          apierror.ErrBadRequest,
+		"MissingSecurityHeader":                           apierror.ErrBadRequest,
+		"NoLoggingStatusForKey":                           apierror.ErrBadRequest,
+		"PreconditionFailed":                              apierror.ErrBadRequest,
+		"RequestIsNotMultiPartContent":                    apierror.ErrBadRequest,
+		"RequestTorrentOfBucketError":                     apierror.ErrBadRequest,
+		"SignatureDoesNotMatch":                           apierror.ErrBadRequest,
+		"TokenRefreshRequired":                            apierror.ErrBadRequest,
+		"UnexpectedContent":                               apierror.ErrBadRequest,
+		"UnresolvableGrantByEmailAddress":                 apierror.ErrBadRequest,
+		"UserKeyMustBeSpecified":                          apierror.ErrBadRequest,
+
+		iam.ErrCodeLimitExceededException:                 apierror.ErrLimitExceeded,
+		iam.ErrCodeReportGenerationLimitExceededException: apierror.ErrLimitExceeded,
+		"MaxMessageLengthExceeded":                        apierror.ErrLimitExceeded,
+		"MaxPostPreDataLengthExceededError":               apierror.ErrLimitExceeded,
+		"MetadataTooLarge":                                apierror.ErrLimitExceeded,
+		"ServiceUnavailable":                              apierror.ErrLimitExceeded,
+		"SlowDown":                                        apierror.ErrLimitExceeded,
+		"TooManyBuckets":                                  apierror.ErrLimitExceeded,
+
+		iam.ErrCodeServiceFailureException:      apierror.ErrServiceUnavailable,
+		iam.ErrCodeServiceNotSupportedException: apierror.ErrServiceUnavailable,
+		"InvalidPayer":                          apierror.ErrServiceUnavailable,
+		"InternalError":                         apierror.ErrServiceUnavailable,
+		"InvalidSecurity":                       apierror.ErrServiceUnavailable,
+		"NotImplemented":                        apierror.ErrServiceUnavailable,
+		"NotSignedUp":                           apierror.ErrServiceUnavailable,
+		"PermanentRedirect":                     apierror.ErrServiceUnavailable,
+		"Redirect":                              apierror.ErrServiceUnavailable,
+		"RequestTimeout":                        apierror.ErrServiceUnavailable,
+		"RequestTimeTooSkewed":                  apierror.ErrServiceUnavailable,
+		"TemporaryRedirect":                     apierror.ErrServiceUnavailable,
+	}
+
+	for awsErr, apiErr := range apiErrorTestCases {
+		err := ErrCode("test error", awserr.New(awsErr, awsErr, nil))
+		if aerr, ok := errors.Cause(err).(apierror.Error); ok {
+			t.Logf("got apierror '%s'", aerr)
+		} else {
+			t.Errorf("expected cloudwatch error %s to be an apierror.Error %s, got %s", awsErr, apiErr, err)
+		}
+	}
+
+	err := ErrCode("test error", errors.New("Unknown"))
+	if aerr, ok := errors.Cause(err).(apierror.Error); ok {
+		t.Logf("got apierror '%s'", aerr)
+	} else {
+		t.Errorf("expected unknown error to be an apierror.ErrInternalError, got %s", err)
+	}
+}

--- a/s3datarepository/s3datarepository.go
+++ b/s3datarepository/s3datarepository.go
@@ -20,6 +20,8 @@ import (
 	"github.com/aws/aws-sdk-go/service/iam/iamiface"
 	"github.com/aws/aws-sdk-go/service/s3"
 	"github.com/aws/aws-sdk-go/service/s3/s3iface"
+	"github.com/aws/aws-sdk-go/service/s3/s3manager"
+	"github.com/aws/aws-sdk-go/service/s3/s3manager/s3manageriface"
 	"github.com/aws/aws-sdk-go/service/sts"
 	"github.com/aws/aws-sdk-go/service/sts/stsiface"
 	log "github.com/sirupsen/logrus"
@@ -35,6 +37,7 @@ type S3Repository struct {
 	EC2           ec2iface.EC2API
 	IAM           iamiface.IAMAPI
 	S3            s3iface.S3API
+	S3Uploader    s3manageriface.UploaderAPI
 	STS           stsiface.STSAPI
 	config        *aws.Config
 }
@@ -96,6 +99,7 @@ func New(opts ...S3RepositoryOption) (*S3Repository, error) {
 	s.EC2 = ec2.New(sess)
 	s.IAM = iam.New(sess)
 	s.S3 = s3.New(sess)
+	s.S3Uploader = s3manager.NewUploaderWithClient(s.S3)
 	s.STS = sts.New(sess)
 
 	return &s, nil


### PR DESCRIPTION
Added a new `AttachmentRepository` interface for managing attachments, currently supports Create and List. The list generates pre-signed URLs for each attachment.