### PR TITLE
Add endpoints for updating and promoting datasets

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,10 +176,9 @@ GET /v1/ds/{account}/datasets/{id}
 
 PATCH /v1/ds/{account}/datasets/{id}
 
-```json
-{
-	"modified_by": "awong"
-}
+Headers:
+```
+X-Forwarded-User: awong
 ```
 
 #### Response
@@ -225,11 +224,16 @@ PATCH /v1/ds/{account}/datasets/{id}
 
 PUT /v1/ds/{account}/datasets/{id}
 
+Headers:
+```
+X-Forwarded-User: awong
+```
+
+Request:
 ```json
 {
 	"metadata": {
-		"description": "It's actually a tiny dataset",
-		"modified_by": "awong"
+		"description": "It's actually a tiny dataset"
 	}
 }
 ```

--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ GET /v1/ds/metrics
 
 POST /v1/ds/{account}/datasets
 GET /v1/ds/{account}/datasets/{id}
+PATCH /v1/ds/{account}/datasets/{id}
+PUT /v1/ds/{account}/datasets/{id}
 DELETE /v1/ds/{account}/datasets/{id}
 
 POST /v1/ds/{account}/datasets/{id}/attachments
@@ -158,6 +160,106 @@ GET /v1/ds/{account}/datasets/{id}
                 "key": "Name",
                 "value": "awesome-dataset-of-stuff"
             }
+        ]
+    }
+}
+```
+
+| Response Code                 | Definition                           |
+| ----------------------------- | -------------------------------------|
+| **200 OK**                    | okay                                 |
+| **400 Bad Request**           | badly formed request                 |
+| **404 Not Found**             | dataset not found                    |
+| **500 Internal Server Error** | a server error occurred              |
+
+### Promote a dataset
+
+PATCH /v1/ds/{account}/datasets/{id}
+
+```json
+{
+	"modified_by": "awong"
+}
+```
+
+#### Response
+
+```json
+{
+    "id": "bb4f6316-53e2-45ae-97c7-fa7fd17f78a8",
+    "metadata": {
+        "id": "bb4f6316-53e2-45ae-97c7-fa7fd17f78a8",
+        "name": "awesome-dataset-of-stuff",
+        "description": "The hugest dataset of awesome stuff",
+        "created_at": "2020-03-16T15:38:14Z",
+        "created_by": "drzoidberg",
+        "data_classifications": [
+            "hipaa",
+            "pii"
+        ],
+        "data_format": "file",
+        "data_storage": "s3",
+        "derivative": false,
+        "dua_url": "https://allmydata.s3.amazonaws.com/duas/huge_awesome_dua.pdf",
+        "finalized_at": "2020-06-01T19:27:35Z",
+        "finalized_by": "awong",
+        "modified_at": "2020-06-01T19:27:35Z",
+        "modified_by": "awong",
+        "proctor_response_url": "https://allmydata.s3.amazonaws.com/proctor/huge_awesome_study.json",
+        "source_ids": [
+            "d37b375b-d136-4b17-8666-5036dc554a66",
+        ]
+    }
+}
+```
+
+| Response Code                 | Definition                           |
+| ----------------------------- | -------------------------------------|
+| **200 OK**                    | okay                                 |
+| **400 Bad Request**           | badly formed request                 |
+| **404 Not Found**             | dataset not found                    |
+| **409 Conflict**              | dataset already finalized            |
+| **500 Internal Server Error** | a server error occurred              |
+
+### Update dataset metadata
+
+PUT /v1/ds/{account}/datasets/{id}
+
+```json
+{
+	"metadata": {
+		"description": "It's actually a tiny dataset",
+		"modified_by": "awong"
+	}
+}
+```
+
+#### Response
+
+```json
+{
+    "id": "bb4f6316-53e2-45ae-97c7-fa7fd17f78a8",
+    "metadata": {
+        "id": "bb4f6316-53e2-45ae-97c7-fa7fd17f78a8",
+        "name": "awesome-dataset-of-stuff",
+        "description": "It's actually a tiny dataset",
+        "created_at": "2020-03-16T15:38:14Z",
+        "created_by": "drzoidberg",
+        "data_classifications": [
+            "hipaa",
+            "pii"
+        ],
+        "data_format": "file",
+        "data_storage": "s3",
+        "derivative": false,
+        "dua_url": "https://allmydata.s3.amazonaws.com/duas/huge_awesome_dua.pdf",
+        "finalized_at": "2020-06-01T19:27:35Z",
+        "finalized_by": "awong",
+        "modified_at": "2020-06-01T21:31:05Z",
+        "modified_by": "awong",
+        "proctor_response_url": "https://allmydata.s3.amazonaws.com/proctor/huge_awesome_study.json",
+        "source_ids": [
+            "d37b375b-d136-4b17-8666-5036dc554a66",
         ]
     }
 }

--- a/api/handlers_datasets.go
+++ b/api/handlers_datasets.go
@@ -168,7 +168,7 @@ func (s *server) DatasetListHandler(w http.ResponseWriter, r *http.Request) {
 	w.Write([]byte{})
 }
 
-// DatasetShowHandler returns information about a a dataset
+// DatasetShowHandler returns information about a dataset
 func (s *server) DatasetShowHandler(w http.ResponseWriter, r *http.Request) {
 	w = LogWriter{w}
 	vars := mux.Vars(r)
@@ -234,17 +234,141 @@ func (s *server) DatasetShowHandler(w http.ResponseWriter, r *http.Request) {
 	w.Write(j)
 }
 
+// DatasetPromoteHandler promotes a dataset
+// If this is an original dataset, it will be finalized (if not already finalized)
+// If this is a derivative, it will be promoted to an original and instantly finalized
+func (s *server) DatasetPromoteHandler(w http.ResponseWriter, r *http.Request) {
+	w = LogWriter{w}
+	vars := mux.Vars(r)
+	account := vars["account"]
+	id := vars["id"]
+
+	service, ok := s.datasetServices[account]
+	if !ok {
+		msg := fmt.Sprintf("account not found: %s", account)
+		handleError(w, apierror.New(apierror.ErrNotFound, msg, nil))
+		return
+	}
+
+	input := struct {
+		ModifiedBy string `json:"modified_by"`
+	}{}
+
+	err := json.NewDecoder(r.Body).Decode(&input)
+	if err != nil {
+		msg := fmt.Sprintf("cannot decode body into promote dataset input: %s", err)
+		handleError(w, apierror.New(apierror.ErrBadRequest, msg, err))
+		return
+	}
+
+	if input.ModifiedBy == "" {
+		handleError(w, apierror.New(apierror.ErrBadRequest, "modified_by is required", nil))
+		return
+	}
+
+	// finalize repository metadata
+	metadataOutput, err := service.MetadataRepository.Promote(r.Context(), account, id, input.ModifiedBy)
+	if err != nil {
+		handleError(w, err)
+		return
+	}
+
+	output := struct {
+		ID       string            `json:"id"`
+		Metadata *dataset.Metadata `json:"metadata"`
+	}{
+		id,
+		metadataOutput,
+	}
+
+	j, err := json.Marshal(&output)
+	if err != nil {
+		msg := fmt.Sprintf("cannot encode dataset output into json: %s", err)
+		handleError(w, apierror.New(apierror.ErrBadRequest, msg, err))
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	w.Write(j)
+}
+
+// DatasetUpdateHandler updates metadata for a dataset
+// Only the following fields can be updated: Description, ModifiedBy
 func (s *server) DatasetUpdateHandler(w http.ResponseWriter, r *http.Request) {
 	w = LogWriter{w}
 	vars := mux.Vars(r)
 	account := vars["account"]
-	dataset := vars["id"]
+	id := vars["id"]
 
-	log.Debugf("updating data set %s for account %s", dataset, account)
+	service, ok := s.datasetServices[account]
+	if !ok {
+		msg := fmt.Sprintf("account not found: %s", account)
+		handleError(w, apierror.New(apierror.ErrNotFound, msg, nil))
+		return
+	}
+
+	// TODO: currently we only support updating the metadata for a dataset, eventually we should update tags as well
+	input := struct {
+		Metadata *dataset.Metadata `json:"metadata"`
+	}{}
+
+	err := json.NewDecoder(r.Body).Decode(&input)
+	if err != nil {
+		msg := fmt.Sprintf("cannot decode body into update dataset input: %s", err)
+		handleError(w, apierror.New(apierror.ErrBadRequest, msg, err))
+		return
+	}
+
+	if input.Metadata == nil {
+		handleError(w, apierror.New(apierror.ErrBadRequest, "dataset metadata is required", nil))
+		return
+	}
+
+	log.Debugf("updating data set %s for account %s", id, account)
+
+	// get current metadata from repository
+	metadata, err := service.MetadataRepository.Get(r.Context(), account, id)
+	if err != nil {
+		handleError(w, err)
+		return
+	}
+
+	// override allowed metadata fields
+	if input.Metadata.Description != "" {
+		metadata.Description = input.Metadata.Description
+	}
+
+	if input.Metadata.ModifiedBy != "" {
+		metadata.ModifiedBy = input.Metadata.ModifiedBy
+	}
+
+	// update metadata
+	metadataOutput, err := service.MetadataRepository.Update(r.Context(), account, id, metadata)
+	if err != nil {
+		msg := fmt.Sprintf("failed to delete metadata for dataset %s", id)
+		handleError(w, apierror.New(apierror.ErrInternalError, msg, err))
+		return
+	}
+
+	output := struct {
+		ID       string            `json:"id"`
+		Metadata *dataset.Metadata `json:"metadata"`
+	}{
+		id,
+		metadataOutput,
+	}
+
+	j, err := json.Marshal(&output)
+	if err != nil {
+		msg := fmt.Sprintf("cannot encode dataset output into json: %s", err)
+		handleError(w, apierror.New(apierror.ErrBadRequest, msg, err))
+		return
+	}
 
 	w.Header().Set("Content-Type", "application/json")
-	w.WriteHeader(http.StatusNotImplemented)
-	w.Write([]byte{})
+	w.WriteHeader(http.StatusOK)
+	w.Write(j)
 }
 
 func (s *server) DatasetDeleteHandler(w http.ResponseWriter, r *http.Request) {

--- a/api/routes.go
+++ b/api/routes.go
@@ -15,6 +15,7 @@ func (s *server) routes() {
 	api.HandleFunc("/{account}/datasets", s.DatasetListHandler).Methods(http.MethodGet)
 	api.HandleFunc("/{account}/datasets", s.DatasetCreateHandler).Methods(http.MethodPost)
 	api.HandleFunc("/{account}/datasets/{id}", s.DatasetShowHandler).Methods(http.MethodGet)
+	api.HandleFunc("/{account}/datasets/{id}", s.DatasetPromoteHandler).Methods(http.MethodPatch)
 	api.HandleFunc("/{account}/datasets/{id}", s.DatasetUpdateHandler).Methods(http.MethodPut)
 	api.HandleFunc("/{account}/datasets/{id}", s.DatasetDeleteHandler).Methods(http.MethodDelete)
 

--- a/dataset/dataset.go
+++ b/dataset/dataset.go
@@ -19,6 +19,7 @@ type Service struct {
 type MetadataRepository interface {
 	Create(ctx context.Context, account, id string, metadata *Metadata) (*Metadata, error)
 	Get(ctx context.Context, account, id string) (*Metadata, error)
+	Promote(ctx context.Context, account, id, user string) (*Metadata, error)
 	Update(ctx context.Context, account, id string, metadata *Metadata) (*Metadata, error)
 	Delete(ctx context.Context, account, id string) error
 }

--- a/dataset/dataset.go
+++ b/dataset/dataset.go
@@ -26,10 +26,11 @@ type MetadataRepository interface {
 
 // DataRepository is an interface for data repository
 type DataRepository interface {
-	Provision(ctx context.Context, id string, derivative bool, tags []*Tag) (string, error)
+	Provision(ctx context.Context, id string, tags []*Tag) (string, error)
 	Deprovision(ctx context.Context, id string) error
 	Delete(ctx context.Context, id string) error
 	Describe(ctx context.Context, id string) (*Repository, error)
+	SetPolicy(ctx context.Context, id string, derivative bool) error
 	GrantAccess(ctx context.Context, id, instanceID string) (Access, error)
 	ListAccess(ctx context.Context, id string) (Access, error)
 	RevokeAccess(ctx context.Context, id, instanceID string) error

--- a/dataset/metadata.go
+++ b/dataset/metadata.go
@@ -154,13 +154,13 @@ func (m *Metadata) UnmarshalJSON(j []byte) error {
 	}
 
 	if finalizedAt, ok := rawStrings["finalized_at"]; ok {
-		ma, ok := finalizedAt.(string)
+		fa, ok := finalizedAt.(string)
 		if !ok {
 			msg := fmt.Sprintf("finalized_at is not a string: %+v", rawStrings["finalized_at"])
 			return errors.New(msg)
 		}
-		if ma != "" {
-			t, err := time.Parse(time.RFC3339, ma)
+		if fa != "" {
+			t, err := time.Parse(time.RFC3339, fa)
 			if err != nil {
 				msg := fmt.Sprintf("failed to parse finalized_at as time: %+v", t)
 				return errors.New(msg)

--- a/dataset/metadata.go
+++ b/dataset/metadata.go
@@ -22,6 +22,8 @@ type Metadata struct {
 	DataStorage         string     `json:"data_storage"`
 	Derivative          bool       `json:"derivative"`
 	DuaURL              *url.URL   `json:"dua_url"`
+	FinalizedAt         *time.Time `json:"finalized_at"`
+	FinalizedBy         string     `json:"finalized_by"`
 	ModifiedAt          *time.Time `json:"modified_at"`
 	ModifiedBy          string     `json:"modified_by"`
 	ProctorResponseURL  *url.URL   `json:"proctor_response_url"`
@@ -151,6 +153,31 @@ func (m *Metadata) UnmarshalJSON(j []byte) error {
 		m.DuaURL = u
 	}
 
+	if finalizedAt, ok := rawStrings["finalized_at"]; ok {
+		ma, ok := finalizedAt.(string)
+		if !ok {
+			msg := fmt.Sprintf("finalized_at is not a string: %+v", rawStrings["finalized_at"])
+			return errors.New(msg)
+		}
+		if ma != "" {
+			t, err := time.Parse(time.RFC3339, ma)
+			if err != nil {
+				msg := fmt.Sprintf("failed to parse finalized_at as time: %+v", t)
+				return errors.New(msg)
+			}
+			m.FinalizedAt = &t
+		}
+	}
+
+	if finalizedBy, ok := rawStrings["finalized_by"]; ok {
+		s, ok := finalizedBy.(string)
+		if !ok {
+			msg := fmt.Sprintf("finalized_by is not a string: %+v", rawStrings["finalized_by"])
+			return errors.New(msg)
+		}
+		m.FinalizedBy = s
+	}
+
 	if modifiedAt, ok := rawStrings["modified_at"]; ok {
 		ma, ok := modifiedAt.(string)
 		if !ok {
@@ -226,6 +253,11 @@ func (m Metadata) MarshalJSON() ([]byte, error) {
 		duaURL = m.DuaURL.String()
 	}
 
+	finalizedAt := ""
+	if m.FinalizedAt != nil {
+		finalizedAt = m.FinalizedAt.Format(time.RFC3339)
+	}
+
 	modifiedAt := ""
 	if m.ModifiedAt != nil {
 		modifiedAt = m.ModifiedAt.Format(time.RFC3339)
@@ -247,6 +279,8 @@ func (m Metadata) MarshalJSON() ([]byte, error) {
 		DataStorage         string   `json:"data_storage"`
 		Derivative          bool     `json:"derivative"`
 		DuaURL              string   `json:"dua_url"`
+		FinalizedAt         string   `json:"finalized_at"`
+		FinalizedBy         string   `json:"finalized_by"`
 		ModifiedAt          string   `json:"modified_at"`
 		ModifiedBy          string   `json:"modified_by"`
 		ProctorResponseURL  string   `json:"proctor_response_url"`
@@ -262,6 +296,8 @@ func (m Metadata) MarshalJSON() ([]byte, error) {
 		DataStorage:         m.DataStorage,
 		Derivative:          m.Derivative,
 		DuaURL:              duaURL,
+		FinalizedAt:         finalizedAt,
+		FinalizedBy:         m.FinalizedBy,
 		ModifiedAt:          modifiedAt,
 		ModifiedBy:          m.ModifiedBy,
 		ProctorResponseURL:  proctorResponseURL,

--- a/dataset/metadata_test.go
+++ b/dataset/metadata_test.go
@@ -21,6 +21,8 @@ func TestMetadataUnmarshalJSON(t *testing.T) {
 		"data_storage": "s3",
 		"derivative": false,
 		"dua_url": "https://allmydata.s3.amazonaws.com/duas/alien_dua.pdf",
+		"finalized_at": "2013-06-21T10:10:01.123Z",
+		"finalized_by": "zbrannigan",
 		"modified_at": "2015-11-21T04:19:01.123Z",
 		"modified_by": "kkroker",
 		"proctor_response_url": "https://allmydata.s3.amazonaws.com/proctor/alien_study.json",
@@ -32,6 +34,7 @@ func TestMetadataUnmarshalJSON(t *testing.T) {
 	}`)
 
 	var createdAt, _ = time.Parse(time.RFC3339, "2013-06-19T19:14:01.123Z")
+	var finalizedAt, _ = time.Parse(time.RFC3339, "2013-06-21T10:10:01.123Z")
 	var modifiedAt, _ = time.Parse(time.RFC3339, "2015-11-21T04:19:01.123Z")
 	var duaURL, _ = url.Parse("https://allmydata.s3.amazonaws.com/duas/alien_dua.pdf")
 	var procURL, _ = url.Parse("https://allmydata.s3.amazonaws.com/proctor/alien_study.json")
@@ -46,6 +49,8 @@ func TestMetadataUnmarshalJSON(t *testing.T) {
 		DataStorage:         "s3",
 		Derivative:          false,
 		DuaURL:              duaURL,
+		FinalizedAt:         &finalizedAt,
+		FinalizedBy:         "zbrannigan",
 		ModifiedAt:          &modifiedAt,
 		ModifiedBy:          "kkroker",
 		ProctorResponseURL:  procURL,
@@ -126,6 +131,21 @@ func TestMetadataUnmarshalJSON(t *testing.T) {
 		t.Error("expected error for bad dua_url, got nil")
 	}
 
+	// finalized_at type
+	if err := out.UnmarshalJSON([]byte(`{"finalized_at":false}`)); err == nil {
+		t.Error("expected error for bad finalized_at, got nil")
+	}
+
+	// finalized_at date type
+	if err := out.UnmarshalJSON([]byte(`{"finalized_at":"12345"}`)); err == nil {
+		t.Error("expected error for bad finalized_at, got nil")
+	}
+
+	// finalized_by type
+	if err := out.UnmarshalJSON([]byte(`{"finalized_by":false}`)); err == nil {
+		t.Error("expected error for bad finalized_by, got nil")
+	}
+
 	// modified_at type
 	if err := out.UnmarshalJSON([]byte(`{"modified_at":false}`)); err == nil {
 		t.Error("expected error for bad modified_at, got nil")
@@ -166,6 +186,7 @@ func TestMetadataMarshalJSON(t *testing.T) {
 	}
 
 	createdAt, _ := time.Parse(time.RFC3339, "2013-06-19T19:14:01.123Z")
+	finalizedAt, _ := time.Parse(time.RFC3339, "2013-06-21T10:10:01.123Z")
 	modifiedAt, _ := time.Parse(time.RFC3339, "2015-11-21T04:19:01.123Z")
 	duaURL, _ := url.Parse("https://allmydata.s3.amazonaws.com/duas/alien_dua.pdf")
 	procURL, _ := url.Parse("https://allmydata.s3.amazonaws.com/proctor/alien_study.json")
@@ -173,7 +194,7 @@ func TestMetadataMarshalJSON(t *testing.T) {
 	tests := []test{
 		test{
 			Metadata{},
-			[]byte(`{"id":"","name":"","description":"","created_at":"","created_by":"","data_classifications":null,"data_format":"","data_storage":"","derivative":false,"dua_url":"","modified_at":"","modified_by":"","proctor_response_url":"","source_ids":null}`),
+			[]byte(`{"id":"","name":"","description":"","created_at":"","created_by":"","data_classifications":null,"data_format":"","data_storage":"","derivative":false,"dua_url":"","finalized_at":"","finalized_by":"","modified_at":"","modified_by":"","proctor_response_url":"","source_ids":null}`),
 			nil,
 		},
 		test{
@@ -188,6 +209,8 @@ func TestMetadataMarshalJSON(t *testing.T) {
 				DataStorage:         "s3",
 				Derivative:          false,
 				DuaURL:              duaURL,
+				FinalizedAt:         &finalizedAt,
+				FinalizedBy:         "zbrannigan",
 				ModifiedAt:          &modifiedAt,
 				ModifiedBy:          "kkroker",
 				ProctorResponseURL:  procURL,
@@ -197,7 +220,7 @@ func TestMetadataMarshalJSON(t *testing.T) {
 					"c00925d6-2eef-4fb6-aef1-87152613222c",
 				},
 			},
-			[]byte(`{"id":"08d754ba-8540-4fdc-92f3-47950c1cdb1c","name":"alien-sightings-dataset","description":"Alien sightings","created_at":"2013-06-19T19:14:01Z","created_by":"zbrannigan","data_classifications":["extremelyclassified"],"data_format":"file","data_storage":"s3","derivative":false,"dua_url":"https://allmydata.s3.amazonaws.com/duas/alien_dua.pdf","modified_at":"2015-11-21T04:19:01Z","modified_by":"kkroker","proctor_response_url":"https://allmydata.s3.amazonaws.com/proctor/alien_study.json","source_ids":["ea19d935-6ca3-4711-8e3e-24713cc3ac00","801e1c4f-58ff-4f14-af1f-0fd6a09cdaef","c00925d6-2eef-4fb6-aef1-87152613222c"]}`),
+			[]byte(`{"id":"08d754ba-8540-4fdc-92f3-47950c1cdb1c","name":"alien-sightings-dataset","description":"Alien sightings","created_at":"2013-06-19T19:14:01Z","created_by":"zbrannigan","data_classifications":["extremelyclassified"],"data_format":"file","data_storage":"s3","derivative":false,"dua_url":"https://allmydata.s3.amazonaws.com/duas/alien_dua.pdf","finalized_at":"2013-06-21T10:10:01Z","finalized_by":"zbrannigan","modified_at":"2015-11-21T04:19:01Z","modified_by":"kkroker","proctor_response_url":"https://allmydata.s3.amazonaws.com/proctor/alien_study.json","source_ids":["ea19d935-6ca3-4711-8e3e-24713cc3ac00","801e1c4f-58ff-4f14-af1f-0fd6a09cdaef","c00925d6-2eef-4fb6-aef1-87152613222c"]}`),
 			nil,
 		},
 	}

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -28,7 +28,7 @@ RUN chmod 555 /app/api
 RUN apk add --no-cache bash ca-certificates
 
 # Install Deco
-ARG DECO_VERSION=0.4.1
+ARG DECO_VERSION=0.5.0
 ARG DECO_OS=linux
 ARG DECO_ARCH=amd64
 ADD https://github.com/YaleUniversity/deco/releases/download/v${DECO_VERSION}/deco-v${DECO_VERSION}-${DECO_OS}-${DECO_ARCH} /usr/local/bin/deco

--- a/docker/import_config.sh
+++ b/docker/import_config.sh
@@ -10,8 +10,8 @@ if [ -n "$SSMPATH" ]; then
     echo "ERROR: deco not found!"
     exit 1
   fi
-  deco validate ssm://${SSMPATH} || exit 1
-  deco run ssm://${SSMPATH}
+  deco validate -e ssm://${SSMPATH} || exit 1
+  deco run -e ssm://${SSMPATH}
 else
   echo "ERROR: SSMPATH variable not set!"
   exit 1

--- a/s3datarepository/iam.go
+++ b/s3datarepository/iam.go
@@ -896,6 +896,14 @@ func (s *S3Repository) derivativeAccessPolicy(bucket string) ([]byte, error) {
 					"s3:PutObject",
 				},
 			},
+			PolicyStatement{
+				Resource: []string{fmt.Sprintf("arn:aws:s3:::%s/_attachments/*", bucket)},
+				Effect:   "Deny",
+				Action: []string{
+					"s3:DeleteObject",
+					"s3:PutObject",
+				},
+			},
 		},
 	})
 

--- a/s3datarepository/iam_test.go
+++ b/s3datarepository/iam_test.go
@@ -386,6 +386,14 @@ func (i *mockIAMClient) ListAttachedRolePoliciesWithContext(ctx context.Context,
 	return output, nil
 }
 
+func (i *mockIAMClient) ListPolicyVersionsWithContext(ctx context.Context, input *iam.ListPolicyVersionsInput, opts ...request.Option) (*iam.ListPolicyVersionsOutput, error) {
+	if err, ok := i.err["ListPolicyVersionsWithContext"]; ok {
+		return nil, err
+	}
+
+	return &iam.ListPolicyVersionsOutput{}, nil
+}
+
 func (i *mockIAMClient) ListInstanceProfilesForRoleWithContext(ctx context.Context, input *iam.ListInstanceProfilesForRoleInput, opts ...request.Option) (*iam.ListInstanceProfilesForRoleOutput, error) {
 	if err, ok := i.err["ListInstanceProfilesForRoleWithContext"]; ok {
 		return nil, err

--- a/s3datarepository/iam_test.go
+++ b/s3datarepository/iam_test.go
@@ -263,6 +263,20 @@ func (i *mockIAMClient) CreatePolicyWithContext(ctx context.Context, input *iam.
 	return &iam.CreatePolicyOutput{Policy: output}, nil
 }
 
+func (i *mockIAMClient) CreatePolicyVersionWithContext(ctx context.Context, input *iam.CreatePolicyVersionInput, opts ...request.Option) (*iam.CreatePolicyVersionOutput, error) {
+	if err, ok := i.err["CreatePolicyVersionWithContext"]; ok {
+		return nil, err
+	}
+
+	output := &iam.PolicyVersion{
+		CreateDate:       &testTime,
+		IsDefaultVersion: input.SetAsDefault,
+		VersionId:        aws.String("v2"),
+	}
+
+	return &iam.CreatePolicyVersionOutput{PolicyVersion: output}, nil
+}
+
 func (i *mockIAMClient) CreateRoleWithContext(ctx context.Context, input *iam.CreateRoleInput, opts ...request.Option) (*iam.CreateRoleOutput, error) {
 	if err, ok := i.err["CreateRoleWithContext"]; ok {
 		return nil, err
@@ -332,6 +346,23 @@ func (i *mockIAMClient) GetInstanceProfileWithContext(ctx context.Context, input
 			},
 		},
 	}
+
+	return output, nil
+}
+
+func (i *mockIAMClient) GetPolicyWithContext(ctx context.Context, input *iam.GetPolicyInput, opts ...request.Option) (*iam.GetPolicyOutput, error) {
+	if err, ok := i.err["GetPolicyWithContext"]; ok {
+		return nil, err
+	}
+
+	output := &iam.GetPolicyOutput{Policy: &iam.Policy{
+		Arn:         input.PolicyArn,
+		CreateDate:  &testTime,
+		Description: aws.String("Test policy"),
+		Path:        aws.String("/test/"),
+		PolicyId:    aws.String("TESTPOLICYID123"),
+		PolicyName:  input.PolicyArn,
+	}}
 
 	return output, nil
 }

--- a/s3datarepository/s3datarepository_test.go
+++ b/s3datarepository/s3datarepository_test.go
@@ -245,7 +245,7 @@ func TestProvision(t *testing.T) {
 	s.S3.(*mockS3Client).err["HeadBucketWithContext"] = awserr.New("NotFound", "bucket not found", nil)
 	expected := "68004EEC-6044-45C9-91E5-AF836DCD9234"
 
-	got, err := s.Provision(context.TODO(), "68004EEC-6044-45C9-91E5-AF836DCD9234", false, testTags)
+	got, err := s.Provision(context.TODO(), "68004EEC-6044-45C9-91E5-AF836DCD9234", testTags)
 	if err != nil {
 		t.Errorf("expected nil error, got: %s", err)
 	}
@@ -258,7 +258,7 @@ func TestProvision(t *testing.T) {
 	s.S3.(*mockS3Client).err["HeadBucketWithContext"] = awserr.New("NotFound", "bucket not found", nil)
 	expected = "dataset-68004EEC-6044-45C9-91E5-AF836DCD9234"
 
-	got, err = s.Provision(context.TODO(), "68004EEC-6044-45C9-91E5-AF836DCD9234", false, []*dataset.Tag{})
+	got, err = s.Provision(context.TODO(), "68004EEC-6044-45C9-91E5-AF836DCD9234", []*dataset.Tag{})
 	if err != nil {
 		t.Errorf("expected nil error, got: %s", err)
 	}
@@ -272,7 +272,7 @@ func TestProvision(t *testing.T) {
 	expectedCode = apierror.ErrBadRequest
 	expectedMessage = "invalid input"
 
-	_, err = s.Provision(context.TODO(), id, false, testTags)
+	_, err = s.Provision(context.TODO(), id, testTags)
 	if err == nil {
 		t.Error("expected error, got: nil")
 	} else {
@@ -294,7 +294,7 @@ func TestProvision(t *testing.T) {
 	expectedCode = apierror.ErrConflict
 	expectedMessage = "s3 bucket already exists"
 
-	_, err = s.Provision(context.TODO(), id, false, testTags)
+	_, err = s.Provision(context.TODO(), id, testTags)
 	if err == nil {
 		t.Error("expected error, got: nil")
 	} else {
@@ -318,7 +318,7 @@ func TestProvision(t *testing.T) {
 	s.S3.(*mockS3Client).err["HeadBucketWithContext"] = awserr.New("NotFound", "bucket not found", nil)
 	s.S3.(*mockS3Client).err["CreateBucketWithContext"] = awserr.New("InternalError", "Internal Error", nil)
 
-	_, err = s.Provision(context.TODO(), id, false, testTags)
+	_, err = s.Provision(context.TODO(), id, testTags)
 	if err == nil {
 		t.Error("expected error, got: nil")
 	} else {
@@ -340,7 +340,7 @@ func TestProvision(t *testing.T) {
 	expectedCode = apierror.ErrInternalError
 	expectedMessage = fmt.Sprintf("failed to create bucket dataset-%s, timeout waiting for create: NoSuchBucket: Not Found", id)
 
-	_, err = s.Provision(context.TODO(), id, false, testTags)
+	_, err = s.Provision(context.TODO(), id, testTags)
 	if err == nil {
 		t.Error("expected error, got: nil")
 	} else {
@@ -364,7 +364,7 @@ func TestProvision(t *testing.T) {
 	s.S3.(*mockS3Client).err["HeadBucketWithContext"] = awserr.New("NotFound", "bucket not found", nil)
 	s.S3.(*mockS3Client).err["PutPublicAccessBlockWithContext"] = awserr.New("InternalError", "Internal Error", nil)
 
-	_, err = s.Provision(context.TODO(), id, false, testTags)
+	_, err = s.Provision(context.TODO(), id, testTags)
 	if err == nil {
 		t.Error("expected error, got: nil")
 	} else {
@@ -388,7 +388,7 @@ func TestProvision(t *testing.T) {
 	s.S3.(*mockS3Client).err["HeadBucketWithContext"] = awserr.New("NotFound", "bucket not found", nil)
 	s.S3.(*mockS3Client).err["PutBucketEncryptionWithContext"] = awserr.New("InternalError", "Internal Error", nil)
 
-	_, err = s.Provision(context.TODO(), id, false, testTags)
+	_, err = s.Provision(context.TODO(), id, testTags)
 	if err == nil {
 		t.Error("expected error, got: nil")
 	} else {
@@ -412,7 +412,7 @@ func TestProvision(t *testing.T) {
 	s.S3.(*mockS3Client).err["HeadBucketWithContext"] = awserr.New("NotFound", "bucket not found", nil)
 	s.S3.(*mockS3Client).err["PutBucketTaggingWithContext"] = awserr.New("InternalError", "Internal Error", nil)
 
-	_, err = s.Provision(context.TODO(), id, false, testTags)
+	_, err = s.Provision(context.TODO(), id, testTags)
 	if err == nil {
 		t.Error("expected error, got: nil")
 	} else {

--- a/s3metadatarepository/s3metadatarepository.go
+++ b/s3metadatarepository/s3metadatarepository.go
@@ -265,8 +265,7 @@ func (s *S3Repository) Promote(ctx context.Context, account, id, user string) (*
 	defer out.Body.Close()
 
 	metadata := &dataset.Metadata{}
-	err = json.NewDecoder(out.Body).Decode(metadata)
-	if err != nil {
+	if err = json.NewDecoder(out.Body).Decode(metadata); err != nil {
 		return nil, apierror.New(apierror.ErrBadRequest, "failed to decode json from s3", err)
 	}
 


### PR DESCRIPTION
PATCH allows promoting a derivative dataset to an original, and also finalizing an original dataset
PUT can update arbitrary _allowed_ metadata fields (currently just `Description`)

In addition, I moved the policy logic into a `SetPolicy` function which handles both initial creation and updates to a dataset policy (currently when we promote a derivative to original). I also had to update the "delete" policy to handle multiple IAM policy versions.