### PR TITLE
Add support for S3 server access logging

### DIFF
--- a/api/server.go
+++ b/api/server.go
@@ -96,6 +96,7 @@ func NewServer(config common.Config) error {
 				if err != nil {
 					return err
 				}
+				dataRepo.LoggingBucketPrefix = "dataset/" + Org + "/"
 				dataRepo.NamePrefix = "dataset-" + Org
 				dataRepos["s3"] = dataRepo
 

--- a/common/config_test.go
+++ b/common/config_test.go
@@ -26,7 +26,8 @@ var testConfig = []byte(
 				"config": {
 					"region": "us-east-1",
 					"akid": "key1",
-					"secret": "secret1"
+					"secret": "secret1",
+					"loggingBucket": "dsapi-provider1-access-logs"
 				}
 		  },
 		  "provider2": {
@@ -34,7 +35,8 @@ var testConfig = []byte(
 				"config": {
 					"region": "us-west-1",
 					"akid": "key2",
-					"secret": "secret2"
+					"secret": "secret2",
+					"loggingBucket": "dsapi-provider2-access-logs"
 				}
 		  }
 		},
@@ -52,17 +54,19 @@ func TestReadConfig(t *testing.T) {
 			"provider1": Account{
 				StorageProviders: []string{"s3"},
 				Config: map[string]interface{}{
-					"region": "us-east-1",
-					"akid":   "key1",
-					"secret": "secret1",
+					"region":        "us-east-1",
+					"akid":          "key1",
+					"secret":        "secret1",
+					"loggingBucket": "dsapi-provider1-access-logs",
 				},
 			},
 			"provider2": Account{
 				StorageProviders: []string{"s3"},
 				Config: map[string]interface{}{
-					"region": "us-west-1",
-					"akid":   "key2",
-					"secret": "secret2",
+					"region":        "us-west-1",
+					"akid":          "key2",
+					"secret":        "secret2",
+					"loggingBucket": "dsapi-provider2-access-logs",
 				},
 			},
 		},

--- a/config/config.example.json
+++ b/config/config.example.json
@@ -16,7 +16,8 @@
       "config": {
         "region": "us-east-1",
         "akid": "xxxxxxxxxxxxxxxxxxxxxxxx",
-        "secret": "yyyyyyyyyyyyyyyyyyyyyyyyyyyyyy"
+        "secret": "yyyyyyyyyyyyyyyyyyyyyyyyyyyyyy",
+        "loggingBucket": "dsapi-someaccount-access-logs"
       }
     }
   },

--- a/docker/config.deco.json
+++ b/docker/config.deco.json
@@ -16,7 +16,8 @@
       "config": {
         "region": "us-east-1",
         "akid": "{{ .spinup_akid }}",
-        "secret": "{{ .spinup_secret }}"
+        "secret": "{{ .spinup_secret }}",
+        "loggingBucket": "{{ .spinup_logging_bucket }}"
       }
     },
     "spinupsec": {
@@ -24,7 +25,8 @@
       "config": {
         "region": "us-east-1",
         "akid": "{{ .spinupsec_akid }}",
-        "secret": "{{ .spinupsec_secret }}"
+        "secret": "{{ .spinupsec_secret }}",
+        "loggingBucket": "{{ .spinupsec_logging_bucket }}"
       }
     }
   },

--- a/s3datarepository/s3datarepository.go
+++ b/s3datarepository/s3datarepository.go
@@ -85,7 +85,6 @@ func NewDefaultRepository(config map[string]interface{}) (*S3Repository, error) 
 
 	if loggingBucket != "" {
 		opts = append(opts, WithLoggingBucket(loggingBucket))
-		opts = append(opts, WithLoggingBucketPrefix("datasets"))
 	}
 
 	// set default IAMPathPrefix
@@ -378,7 +377,7 @@ func (s *S3Repository) Provision(ctx context.Context, id string, datasetTags []*
 			BucketLoggingStatus: &s3.BucketLoggingStatus{
 				LoggingEnabled: &s3.LoggingEnabled{
 					TargetBucket: aws.String(s.LoggingBucket),
-					TargetPrefix: aws.String(s.LoggingBucketPrefix),
+					TargetPrefix: aws.String(s.LoggingBucketPrefix + id + "/"),
 				},
 			},
 		})

--- a/s3datarepository/s3datarepository_test.go
+++ b/s3datarepository/s3datarepository_test.go
@@ -115,7 +115,6 @@ func TestNewDefaultRepository(t *testing.T) {
 		"loggingBucket": "dsapi-test-access-logs",
 	}
 
-	expectedLoggingBucketPrefix := "datasets"
 	expectedIAMPathPrefix := "/spinup/dataset/"
 
 	s, err := NewDefaultRepository(testConfig)
@@ -141,10 +140,6 @@ func TestNewDefaultRepository(t *testing.T) {
 
 	if s.LoggingBucket == "" {
 		t.Error("expected LoggingBucket to be set, got empty")
-	}
-
-	if s.LoggingBucketPrefix != expectedLoggingBucketPrefix {
-		t.Errorf("expected LoggingBucketPrefix to be '%s', got '%s'", expectedLoggingBucketPrefix, s.LoggingBucketPrefix)
 	}
 
 	if s.IAMPathPrefix != expectedIAMPathPrefix {

--- a/s3datarepository/s3datarepository_test.go
+++ b/s3datarepository/s3datarepository_test.go
@@ -108,12 +108,14 @@ func (m *mockS3Client) PutPublicAccessBlockWithContext(ctx context.Context, inpu
 
 func TestNewDefaultRepository(t *testing.T) {
 	testConfig := map[string]interface{}{
-		"region":   "us-east-1",
-		"akid":     "xxxxx",
-		"secret":   "yyyyy",
-		"endpoint": "https://under.mydesk.amazonaws.com",
+		"region":        "us-east-1",
+		"akid":          "xxxxx",
+		"secret":        "yyyyy",
+		"endpoint":      "https://under.mydesk.amazonaws.com",
+		"loggingBucket": "dsapi-test-access-logs",
 	}
 
+	expectedLoggingBucketPrefix := "datasets"
 	expectedIAMPathPrefix := "/spinup/dataset/"
 
 	s, err := NewDefaultRepository(testConfig)
@@ -135,6 +137,14 @@ func TestNewDefaultRepository(t *testing.T) {
 
 	if s.config.Endpoint == nil {
 		t.Error("expected config Endpoint to be set, got nil")
+	}
+
+	if s.LoggingBucket == "" {
+		t.Error("expected LoggingBucket to be set, got empty")
+	}
+
+	if s.LoggingBucketPrefix != expectedLoggingBucketPrefix {
+		t.Errorf("expected LoggingBucketPrefix to be '%s', got '%s'", expectedLoggingBucketPrefix, s.LoggingBucketPrefix)
 	}
 
 	if s.IAMPathPrefix != expectedIAMPathPrefix {


### PR DESCRIPTION
We can now add a `loggingBucket` config parameter for each account with the bucket to use for collecting access logs for each data set repository.